### PR TITLE
save/check GALE01r2.ini hash

### DIFF
--- a/app/domain/DolphinManager.js
+++ b/app/domain/DolphinManager.js
@@ -117,6 +117,22 @@ export default class DolphinManager {
       );
     }
 
+    // This probably doesn't belong here - should run on booting the app, or something
+    let hashPath = "./app/latest_codelist_hash"
+    const latestHash = fs.readFileSync(hashPath);
+    let iniFile = "./app/dolphin-dev/overwrite/Sys/GameSettings/GALE01r2.ini";
+    let hash = crypto.createHash('sha256');
+    let data = fs.readFileSync(iniFile);
+    hash.update(data);
+    let currentHash = hash.digest('hex');
+    if (currentHash == latestHash) {
+      console.log("GALE01r2.ini matches latest hash");
+    }
+    else {
+      // Do something more substantial here: tell the user
+      console.log("GALE01r2.ini is changed or outdated!");
+    }
+
     try {
       this.isRunning = true;
       const execFilePromise = util.promisify(execFile);

--- a/internals/scripts/CopyDolphin.js
+++ b/internals/scripts/CopyDolphin.js
@@ -1,6 +1,7 @@
 const { execSync } = require('child_process');
 const fs = require('fs-extra');
 const path = require('path');
+const crypto = require('crypto');
 
 // Check if the renderer and main bundles are built
 function CopyDolphin() {
@@ -27,6 +28,7 @@ function CopyDolphin() {
     throw new Error("Platform not yet supported.");
   }
 
+  getLatestIniHash();
   console.log("Finished copying dolphin build!");
 }
 
@@ -106,6 +108,15 @@ function copyForLinux(targetFolder) {
   fs.copySync(overwriteSysFolder, dolphinDestSysFolder);
   fs.removeSync(gitIgnoreDest);
   fs.emptyDirSync(dolphinDestSlippiFolder);
+}
+
+function getLatestIniHash() {
+  const iniFile = "./app/dolphin-dev/overwrite/Sys/GameSettings/GALE01r2.ini";
+  const hash = crypto.createHash('sha256');
+  const data = fs.readFileSync(iniFile);
+  hash.update(data);
+  let latestHash = hash.digest('hex');
+  fs.writeFileSync("./app/latest_codelist_hash", latestHash);
 }
 
 CopyDolphin();


### PR DESCRIPTION
The checking probably doesn't belong in `DolphinManager.js` - probably better to do it on boot and then inform the user. 