### PR TITLE
Headers remain on screen even when scrolling.

### DIFF
--- a/app/app.global.scss
+++ b/app/app.global.scss
@@ -1,11 +1,15 @@
-@import "./colors.global.scss";
-@import "./spacers.global.scss";
+@import './colors.global.scss';
+@import './spacers.global.scss';
 
 body {
   position: relative;
   color: $primary-green;
   height: 100vh;
   background-color: $background-dark;
+}
+
+* {
+  overflow: hidden;
 }
 
 ul {

--- a/app/app.global.scss
+++ b/app/app.global.scss
@@ -1,5 +1,5 @@
-@import './colors.global.scss';
-@import './spacers.global.scss';
+@import "./colors.global.scss";
+@import "./spacers.global.scss";
 
 body {
   position: relative;

--- a/app/components/Console.js
+++ b/app/components/Console.js
@@ -12,6 +12,7 @@ import DismissibleMessage from './common/DismissibleMessage';
 import styles from './Console.scss';
 import SpacedGroup from './common/SpacedGroup';
 import ActionInput from './common/ActionInput';
+import Scroller from './common/Scroller';
 
 const { dialog } = require('electron').remote;
 
@@ -32,6 +33,7 @@ export default class Console extends Component {
     history: PropTypes.object.isRequired,
     store: PropTypes.object.isRequired,
     errors: PropTypes.object.isRequired,
+    topOffset: PropTypes.number.isRequired,
   };
 
   state = {
@@ -353,7 +355,7 @@ export default class Console extends Component {
       </Button>
     );
   }
-    
+
   renderDeleteButton = connection => {
     const status = connection.connectionStatus;
     const isConnected = status === ConnectionStatus.CONNECTED;
@@ -550,67 +552,71 @@ export default class Console extends Component {
     const validation = _.get(this.state, ['formData', 'validation']) || {};
 
     const panes = [
-      { menuItem: "Basic", render: () => <Tab.Pane>
-        <Form.Input
-          name="ipAddress"
-          label="IP Address"
-          defaultValue={formData.ipAddress || connectionSettings.ipAddress}
-          onChange={this.onFieldChange}
-        />
-        <ActionInput
-          name="targetFolder"
-          label="Target Folder"
-          error={!!validation['targetFolder']}
-          value={formData.targetFolder || connectionSettings.targetFolder || ""}
-          onClick={this.onBrowseFolder}
-          handlerParams={[]}
-          showLabelDescription={false}
-          useFormInput={true}
-        />
-        <Form.Field>
-          <label htmlFor="isRealTimeMode">Real-Time Mode</label>
-          <div className={styles['description']}>
-            <strong>Not recommended unless on wired LAN connection.</strong>&nbsp;
-            Real-time mode will attempt to prevent delay from accumulating when mirroring. Using it
-            when on a connection with inconsistent latency will cause extremely choppy playback.
-          </div>
-          <Checkbox
-            id="isRealTimeMode"
-            name="isRealTimeMode"
-            toggle={true}
-            defaultChecked={_.defaultTo(formData.isRealTimeMode, connectionSettings.isRealTimeMode)}
+      {
+        menuItem: "Basic", render: () => <Tab.Pane>
+          <Form.Input
+            name="ipAddress"
+            label="IP Address"
+            defaultValue={formData.ipAddress || connectionSettings.ipAddress}
             onChange={this.onFieldChange}
           />
-        </Form.Field> </Tab.Pane> }, 
-      { menuItem: "Advanced", render: () => <Tab.Pane>
-        <div className={`${styles['description']} ${styles['spacer']}`}>
-          <strong>Only modify if you know what you doing.</strong>&nbsp;
-          These settings let you select an OBS source (e.g. your dolphin capture) 
-          to be shown if the game is active and hidden if the game is inactive.
-          You must install the &nbsp;
-          <a href="https://github.com/Palakis/obs-websocket">OBS Websocket Plugin</a>&nbsp;
-          for this feature to work.
-        </div>
-        <Form.Input
-          name="obsIP"
-          label="OBS Websocket IP:Port"
-          defaultValue={formData.obsIP || connectionSettings.obsIP || ""}
-          placeholder="localhost:4444"
-          onChange={this.onFieldChange}
-        />
-        <Form.Input
-          name="obsPassword"
-          label="OBS Websocket Password"
-          defaultValue={formData.obsPassword || connectionSettings.obsPassword || ""}
-          onChange={this.onFieldChange}
-        />
-        <Form.Input
-          name="obsSourceName"
-          label="OBS Source Name"
-          defaultValue={formData.obsSourceName || connectionSettings.obsSourceName}
-          onChange={this.onFieldChange}
-        />
-      </Tab.Pane>}];
+          <ActionInput
+            name="targetFolder"
+            label="Target Folder"
+            error={!!validation['targetFolder']}
+            value={formData.targetFolder || connectionSettings.targetFolder || ""}
+            onClick={this.onBrowseFolder}
+            handlerParams={[]}
+            showLabelDescription={false}
+            useFormInput={true}
+          />
+          <Form.Field>
+            <label htmlFor="isRealTimeMode">Real-Time Mode</label>
+            <div className={styles['description']}>
+              <strong>Not recommended unless on wired LAN connection.</strong>&nbsp;
+              Real-time mode will attempt to prevent delay from accumulating when mirroring. Using it
+              when on a connection with inconsistent latency will cause extremely choppy playback.
+            </div>
+            <Checkbox
+              id="isRealTimeMode"
+              name="isRealTimeMode"
+              toggle={true}
+              defaultChecked={_.defaultTo(formData.isRealTimeMode, connectionSettings.isRealTimeMode)}
+              onChange={this.onFieldChange}
+            />
+          </Form.Field> </Tab.Pane>,
+      },
+      {
+        menuItem: "Advanced", render: () => <Tab.Pane>
+          <div className={`${styles['description']} ${styles['spacer']}`}>
+            <strong>Only modify if you know what you doing.</strong>&nbsp;
+            These settings let you select an OBS source (e.g. your dolphin capture)
+            to be shown if the game is active and hidden if the game is inactive.
+            You must install the &nbsp;
+            <a href="https://github.com/Palakis/obs-websocket">OBS Websocket Plugin</a>&nbsp;
+                    for this feature to work.
+          </div>
+          <Form.Input
+            name="obsIP"
+            label="OBS Websocket IP:Port"
+            defaultValue={formData.obsIP || connectionSettings.obsIP || ""}
+            placeholder="localhost:4444"
+            onChange={this.onFieldChange}
+          />
+          <Form.Input
+            name="obsPassword"
+            label="OBS Websocket Password"
+            defaultValue={formData.obsPassword || connectionSettings.obsPassword || ""}
+            onChange={this.onFieldChange}
+          />
+          <Form.Input
+            name="obsSourceName"
+            label="OBS Source Name"
+            defaultValue={formData.obsSourceName || connectionSettings.obsSourceName}
+            onChange={this.onFieldChange}
+          />
+        </Tab.Pane>,
+      }];
 
     let errorMessage = null;
     if (validation.targetFolder === "empty") {
@@ -636,8 +642,10 @@ export default class Console extends Component {
             text="Console"
             history={this.props.history}
           />
-          {this.renderContent()}
-          {this.renderEditModal()}
+          <Scroller topOffset={this.props.topOffset}>
+            {this.renderContent()}
+            {this.renderEditModal()}
+          </Scroller>
         </div>
       </PageWrapper>
     );

--- a/app/components/Console.js
+++ b/app/components/Console.js
@@ -33,7 +33,7 @@ export default class Console extends Component {
     history: PropTypes.object.isRequired,
     store: PropTypes.object.isRequired,
     errors: PropTypes.object.isRequired,
-    topOffset: PropTypes.number.isRequired,
+    topNotifOffset: PropTypes.number.isRequired,
   };
 
   state = {
@@ -642,7 +642,7 @@ export default class Console extends Component {
             text="Console"
             history={this.props.history}
           />
-          <Scroller topOffset={this.props.topOffset}>
+          <Scroller topOffset={this.props.topNotifOffset}>
             {this.renderContent()}
             {this.renderEditModal()}
           </Scroller>

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -18,6 +18,7 @@ import DismissibleMessage from './common/DismissibleMessage';
 import PageHeader from './common/PageHeader';
 import FolderBrowser from './common/FolderBrowser';
 import PageWrapper from './PageWrapper';
+import Scroller from './common/Scroller';
 
 export default class FileLoader extends Component {
   static propTypes = {
@@ -318,11 +319,11 @@ export default class FileLoader extends Component {
           text="Replay Browser"
           history={this.props.history}
         />
-        <div className={styles['scroller']}>
+        <Scroller>
           {this.renderGlobalError()}
           {this.renderFilteredFilesNotif(processedFiles)}
           {this.renderFileSelection(processedFiles)}
-        </div>
+        </Scroller>
       </div>
     );
   }

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -45,7 +45,7 @@ export default class FileLoader extends Component {
     const yPos = _.get(this.props.store, ['scrollPosition', 'y']) || 0;
     window.scrollTo(xPos, yPos);
 
-    if (this.props.history.action === "PUSH") {
+    if (this.props.history.action === 'PUSH') {
       // I don't really like this but when returning back to the file loader, the action is "POP"
       // instead of "PUSH", and we don't want to trigger the loader and ruin our ability to restore
       // scroll position when returning to fileLoader from a game
@@ -73,7 +73,8 @@ export default class FileLoader extends Component {
 
     // Have to offset both the height and sticky position of the sidebar when a global notif is
     // active. Wish I knew a better way to do this.
-    const globalNotifHeightPx = _.get(this.props.globalNotifs, ['activeNotif', 'heightPx']) || 0;
+    const globalNotifHeightPx =
+      _.get(this.props.globalNotifs, ['activeNotif', 'heightPx']) || 0;
     const customStyling = {
       height: `calc(100vh - ${globalNotifHeightPx}px)`,
     };
@@ -242,7 +243,7 @@ export default class FileLoader extends Component {
 
   renderLoadingState() {
     const store = this.props.store || {};
-    
+
     return (
       <Loader
         className={styles['loader']}
@@ -317,9 +318,11 @@ export default class FileLoader extends Component {
           text="Replay Browser"
           history={this.props.history}
         />
-        {this.renderGlobalError()}
-        {this.renderFilteredFilesNotif(processedFiles)}
-        {this.renderFileSelection(processedFiles)}
+        <div className={styles['scroller']}>
+          {this.renderGlobalError()}
+          {this.renderFilteredFilesNotif(processedFiles)}
+          {this.renderFileSelection(processedFiles)}
+        </div>
       </div>
     );
   }

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -38,7 +38,7 @@ export default class FileLoader extends Component {
     history: PropTypes.object.isRequired,
     store: PropTypes.object.isRequired,
     errors: PropTypes.object.isRequired,
-    topOffset: PropTypes.number.isRequired,
+    topNotifOffset: PropTypes.number.isRequired,
   };
 
   componentDidMount() {
@@ -75,7 +75,7 @@ export default class FileLoader extends Component {
     // Have to offset both the height and sticky position of the sidebar when a global notif is
     // active. Wish I knew a better way to do this.
     const customStyling = {
-      height: `calc(100vh - ${this.props.topOffset}px)`,
+      height: `calc(100vh - ${this.props.topNotifOffset}px)`,
     };
 
     // We return a div that will serve as a placeholder for our column as well as a fixed
@@ -317,7 +317,7 @@ export default class FileLoader extends Component {
           text="Replay Browser"
           history={this.props.history}
         />
-        <Scroller topOffset={this.props.topOffset}>
+        <Scroller topOffset={this.props.topNotifOffset}>
           {this.renderGlobalError()}
           {this.renderFilteredFilesNotif(processedFiles)}
           {this.renderFileSelection(processedFiles)}

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -312,6 +312,9 @@ export default class FileLoader extends Component {
     const files = store.files || [];
     const processedFiles = this.processFiles(files);
 
+    const scrollerOffset =
+      _.get(this.props.globalNotifs, ['activeNotif', 'heightPx']) || 0;
+
     return (
       <div className="main-padding">
         <PageHeader
@@ -319,7 +322,7 @@ export default class FileLoader extends Component {
           text="Replay Browser"
           history={this.props.history}
         />
-        <Scroller>
+        <Scroller topOffset={scrollerOffset}>
           {this.renderGlobalError()}
           {this.renderFilteredFilesNotif(processedFiles)}
           {this.renderFileSelection(processedFiles)}

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -38,7 +38,7 @@ export default class FileLoader extends Component {
     history: PropTypes.object.isRequired,
     store: PropTypes.object.isRequired,
     errors: PropTypes.object.isRequired,
-    globalNotifs: PropTypes.object.isRequired,
+    topOffset: PropTypes.number.isRequired,
   };
 
   componentDidMount() {
@@ -74,10 +74,8 @@ export default class FileLoader extends Component {
 
     // Have to offset both the height and sticky position of the sidebar when a global notif is
     // active. Wish I knew a better way to do this.
-    const globalNotifHeightPx =
-      _.get(this.props.globalNotifs, ['activeNotif', 'heightPx']) || 0;
     const customStyling = {
-      height: `calc(100vh - ${globalNotifHeightPx}px)`,
+      height: `calc(100vh - ${this.props.topOffset}px)`,
     };
 
     // We return a div that will serve as a placeholder for our column as well as a fixed
@@ -311,8 +309,6 @@ export default class FileLoader extends Component {
     const files = store.files || [];
     const processedFiles = this.processFiles(files);
 
-    const scrollerOffset =
-      _.get(this.props.globalNotifs, ['activeNotif', 'heightPx']) || 0;
 
     return (
       <div className="main-padding">
@@ -321,7 +317,7 @@ export default class FileLoader extends Component {
           text="Replay Browser"
           history={this.props.history}
         />
-        <Scroller topOffset={scrollerOffset}>
+        <Scroller topOffset={this.props.topOffset}>
           {this.renderGlobalError()}
           {this.renderFilteredFilesNotif(processedFiles)}
           {this.renderFileSelection(processedFiles)}

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -46,7 +46,7 @@ export default class FileLoader extends Component {
     const yPos = _.get(this.props.store, ['scrollPosition', 'y']) || 0;
     window.scrollTo(xPos, yPos);
 
-    if (this.props.history.action === 'PUSH') {
+    if (this.props.history.action === "PUSH") {
       // I don't really like this but when returning back to the file loader, the action is "POP"
       // instead of "PUSH", and we don't want to trigger the loader and ruin our ability to restore
       // scroll position when returning to fileLoader from a game
@@ -244,7 +244,6 @@ export default class FileLoader extends Component {
 
   renderLoadingState() {
     const store = this.props.store || {};
-
     return (
       <Loader
         className={styles['loader']}

--- a/app/components/FileLoader.scss
+++ b/app/components/FileLoader.scss
@@ -1,4 +1,4 @@
-@import "../colors.global.scss";
+@import '../colors.global.scss';
 
 .layout {
   display: grid;
@@ -30,13 +30,13 @@
 .play-cell {
   text-align: center;
 
-  button>i {
-    color: #94969A;
+  button > i {
+    color: #94969a;
   }
 
   button:hover {
     i {
-      color: #FFFFFF;
+      color: #ffffff;
     }
   }
 }
@@ -99,4 +99,8 @@
 
 .bound-link {
   display: contents;
+}
+
+.scroller {
+  overflow-y: scroll;
 }

--- a/app/components/FileLoader.scss
+++ b/app/components/FileLoader.scss
@@ -1,4 +1,4 @@
-@import '../colors.global.scss';
+@import "../colors.global.scss";
 
 .layout {
   display: grid;
@@ -30,13 +30,13 @@
 .play-cell {
   text-align: center;
 
-  button > i {
-    color: #94969a;
+  button>i {
+    color: #94969A;
   }
 
   button:hover {
     i {
-      color: #ffffff;
+      color: #FFFFFF;
     }
   }
 }
@@ -99,8 +99,4 @@
 
 .bound-link {
   display: contents;
-}
-
-.scroller {
-  overflow-y: scroll;
 }

--- a/app/components/GlobalAlert.scss
+++ b/app/components/GlobalAlert.scss
@@ -1,34 +1,34 @@
-@import "../colors.global.scss";
+@import '../colors.global.scss';
 
 .alert {
-    top: 0px;
-    position: fixed !important;
-    width: 100% !important;
-    z-index: 1000;
-    margin: 0 !important;
-    border-radius: 0 !important;
+  top: 0px;
+  // position: fixed !important;
+  width: 100% !important;
+  z-index: 1000;
+  margin: 0 !important;
+  border-radius: 0 !important;
 }
 
 .single-line-message {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .main {
-    padding-top: 100px;
+  padding-top: 100px;
 }
 
 .icon {
-    font-size: 24px !important;
+  font-size: 24px !important;
 }
 
 .version-arrow-icon {
-    margin-right: 0 !important;
+  margin-right: 0 !important;
 }
 
 .upgrade-link {
-    margin-left: 6px;
-    cursor: pointer;
-    font-weight: bold;
+  margin-left: 6px;
+  cursor: pointer;
+  font-weight: bold;
 }

--- a/app/components/GlobalAlert.scss
+++ b/app/components/GlobalAlert.scss
@@ -1,34 +1,33 @@
-@import '../colors.global.scss';
+@import "../colors.global.scss";
 
 .alert {
-  top: 0px;
-  // position: fixed !important;
-  width: 100% !important;
-  z-index: 1000;
-  margin: 0 !important;
-  border-radius: 0 !important;
+    top: 0px;
+    width: 100% !important;
+    z-index: 1000;
+    margin: 0 !important;
+    border-radius: 0 !important;
 }
 
 .single-line-message {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .main {
-  padding-top: 100px;
+    padding-top: 100px;
 }
 
 .icon {
-  font-size: 24px !important;
+    font-size: 24px !important;
 }
 
 .version-arrow-icon {
-  margin-right: 0 !important;
+    margin-right: 0 !important;
 }
 
 .upgrade-link {
-  margin-left: 6px;
-  cursor: pointer;
-  font-weight: bold;
+    margin-left: 6px;
+    cursor: pointer;
+    font-weight: bold;
 }

--- a/app/components/PageWrapper.js
+++ b/app/components/PageWrapper.js
@@ -8,10 +8,10 @@ import { connect } from 'react-redux';
 import GlobalAlert from './GlobalAlert';
 import * as NotifActions from '../actions/notifs';
 import * as GameActions from '../actions/game';
-import { playFile } from '../actions/fileLoader';
+import { playFile } from "../actions/fileLoader";
 
 // Originally this logic was supposed to just exist at the App level. For some reason though
-// that broke navigation, so I decided to put the logic after the
+// that broke navigation, so I decided to put the logic after the 
 class PageWrapper extends Component {
   static propTypes = {
     children: PropTypes.any.isRequired,

--- a/app/components/PageWrapper.js
+++ b/app/components/PageWrapper.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import _ from 'lodash';
 import log from 'electron-log';
 import PropTypes from 'prop-types';
 import { ipcRenderer } from 'electron';
@@ -9,17 +8,16 @@ import { connect } from 'react-redux';
 import GlobalAlert from './GlobalAlert';
 import * as NotifActions from '../actions/notifs';
 import * as GameActions from '../actions/game';
-import { playFile } from "../actions/fileLoader";
+import { playFile } from '../actions/fileLoader';
 
 // Originally this logic was supposed to just exist at the App level. For some reason though
-// that broke navigation, so I decided to put the logic after the 
+// that broke navigation, so I decided to put the logic after the
 class PageWrapper extends Component {
   static propTypes = {
     children: PropTypes.any.isRequired,
     history: PropTypes.object.isRequired,
-    
+
     // From redux
-    store: PropTypes.object.isRequired,
     appUpgradeDownloaded: PropTypes.func.isRequired,
     gameProfileLoad: PropTypes.func.isRequired,
     playFile: PropTypes.func.isRequired,
@@ -39,7 +37,7 @@ class PageWrapper extends Component {
     // When main process (main.dev.js) tells us an update has been downloaded, trigger
     // a global notif to be shown
     this.props.appUpgradeDownloaded(upgradeDetails);
-  }
+  };
 
   onPlayReplay = (event, slpPath) => {
     log.info(`playing file ${slpPath}`);
@@ -48,27 +46,12 @@ class PageWrapper extends Component {
     this.props.playFile({
       fullPath: slpPath,
     });
-  }
+  };
 
   render() {
-    let spacerEl = null;
-
-    const notifHeightPx = _.get(this.props.store, ['activeNotif', 'heightPx']);
-    if (notifHeightPx) {
-      const customStyling = {
-        height: `${notifHeightPx}px`,
-      };
-
-      // User spacer element to give space for notif. I tried using padding on the top-level div
-      // and that sorta worked but it didn't seem to respond well when I closed the notif while
-      // on the file loader page, there would still be space above the file selector
-      spacerEl = <div style={customStyling} />;
-    }
-
     return (
       <React.Fragment>
         <GlobalAlert />
-        {spacerEl}
         <div>{this.props.children}</div>
       </React.Fragment>
     );
@@ -82,11 +65,14 @@ function mapStateToProps(state) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({
-    ...NotifActions,
-    ...GameActions,
-    playFile: playFile,
-  }, dispatch);
+  return bindActionCreators(
+    {
+      ...NotifActions,
+      ...GameActions,
+      playFile: playFile,
+    },
+    dispatch
+  );
 }
 
 export default connect(

--- a/app/components/Settings.js
+++ b/app/components/Settings.js
@@ -10,7 +10,6 @@ import DismissibleMessage from './common/DismissibleMessage';
 
 import styles from './Settings.scss';
 import PageWrapper from './PageWrapper';
-import Scroller from './common/Scroller';
 import SpacedGroup from './common/SpacedGroup';
 
 const { app } = require('electron').remote;
@@ -322,7 +321,7 @@ export default class Settings extends Component {
             infoText={`App v${currentVersion}`}
             history={this.props.history}
           />
-          <Scroller>{this.renderContent()}</Scroller>
+          {this.renderContent()}
         </div>
       </PageWrapper>
     );

--- a/app/components/Settings.js
+++ b/app/components/Settings.js
@@ -1,12 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import {
-  Button,
-  Message,
-  Header,
-  Icon,
-} from 'semantic-ui-react';
+import { Button, Message, Header, Icon } from 'semantic-ui-react';
 import { getDefaultDolphinPath } from '../utils/settings';
 import PageHeader from './common/PageHeader';
 import ActionInput from './common/ActionInput';
@@ -15,6 +10,7 @@ import DismissibleMessage from './common/DismissibleMessage';
 
 import styles from './Settings.scss';
 import PageWrapper from './PageWrapper';
+import Scroller from './common/Scroller';
 import SpacedGroup from './common/SpacedGroup';
 
 const { app } = require('electron').remote;
@@ -74,7 +70,8 @@ export default class Settings extends Component {
       <div>
         Hello Linux friend! We cannot include a Dolphin build that is guaranteed
         to work on your distro. Please find the <b>Playback Dolphin Path</b>
-        &nbsp;option to configure. <a href="https://discord.gg/KkhZQfR">Join the discord</a>
+        &nbsp;option to configure.{' '}
+        <a href="https://discord.gg/KkhZQfR">Join the discord</a>
         &nbsp;if you have any questions.
       </div>
     );
@@ -113,34 +110,37 @@ export default class Settings extends Component {
   }
 
   renderISOVersionCheck() {
-    const validationState = _.get(this.props.store, 'isoValidationState') || 'unknown';
+    const validationState =
+      _.get(this.props.store, 'isoValidationState') || 'unknown';
 
     let icon, text, loading;
     switch (validationState) {
-    case "success":
-      icon = "check circle outline";
-      text = "Valid";
+    case 'success':
+      icon = 'check circle outline';
+      text = 'Valid';
       loading = false;
       break;
-    case "fail":
-      icon = "times circle outline";
-      text = "Bad ISO";
+    case 'fail':
+      icon = 'times circle outline';
+      text = 'Bad ISO';
       loading = false;
       break;
-    case "validating":
-      icon = "spinner";
-      text = "Verifying";
+    case 'validating':
+      icon = 'spinner';
+      text = 'Verifying';
       loading = true;
       break;
     default:
-      icon = "question circle outline";
-      text = "";
+      icon = 'question circle outline';
+      text = '';
       loading = false;
       break;
     }
-    
+
     return (
-      <div className={`${styles['iso-version-check']} ${styles[validationState]}`}>
+      <div
+        className={`${styles['iso-version-check']} ${styles[validationState]}`}
+      >
         <span className={styles['iso-verify-text']}>{text}</span>
         <Icon name={icon} fitted={true} loading={loading} size="large" />
       </div>
@@ -158,7 +158,7 @@ export default class Settings extends Component {
           label="Melee ISO File"
           description="The path to a NTSC Melee 1.02 ISO. Used for playing replay files"
           value={store.settings.isoPath}
-          error={isoValidationState === "fail"}
+          error={isoValidationState === 'fail'}
           onClick={this.props.browseFile}
           handlerParams={['isoPath']}
         />
@@ -179,9 +179,7 @@ export default class Settings extends Component {
 
     const platform = process.platform;
     if (platform === 'linux') {
-      inputs.push([
-        this.renderPlaybackInstanceInput(),
-      ]);
+      inputs.push([this.renderPlaybackInstanceInput()]);
     }
 
     return (
@@ -199,9 +197,7 @@ export default class Settings extends Component {
 
     const platform = process.platform;
     if (platform !== 'linux') {
-      inputs.push([
-        this.renderPlaybackInstanceInput(),
-      ]);
+      inputs.push([this.renderPlaybackInstanceInput()]);
     }
 
     if (_.isEmpty(inputs)) {
@@ -222,7 +218,7 @@ export default class Settings extends Component {
 
   renderPlaybackInstanceInput() {
     const store = this.props.store || {};
-    
+
     const platform = process.platform;
 
     // If on Linux, indicate the steps required
@@ -230,9 +226,18 @@ export default class Settings extends Component {
       <div>
         Linux users must build their own playback Dolphin instance
         <ul>
-          <li>Use <a href="https://github.com/project-slippi/Slippi-FM-installer">installer script</a> to compile playback Dolphin</li>
+          <li>
+            Use{' '}
+            <a href="https://github.com/project-slippi/Slippi-FM-installer">
+              installer script
+            </a>{' '}
+            to compile playback Dolphin
+          </li>
           <li>Move the compiled instance out of the build directory</li>
-          <li>Set the field below to point to the directory that contains dolphin-emu</li>
+          <li>
+            Set the field below to point to the directory that contains
+            dolphin-emu
+          </li>
         </ul>
       </div>
     );
@@ -245,8 +250,8 @@ export default class Settings extends Component {
     if (platform !== 'linux') {
       playbackDolphinDescription = (
         <div>
-          An instance of Dolphin for playing replays comes bundled
-          with this app. This setting allows you to configure a different instance.&nbsp;
+          An instance of Dolphin for playing replays comes bundled with this
+          app. This setting allows you to configure a different instance.&nbsp;
           <strong>Only modify if you know what you are doing.</strong>
         </div>
       );
@@ -289,7 +294,7 @@ export default class Settings extends Component {
           {this.renderConfigDolphin()}
         </SpacedGroup>
       </div>
-    )
+    );
   }
 
   renderContent() {
@@ -317,7 +322,7 @@ export default class Settings extends Component {
             infoText={`App v${currentVersion}`}
             history={this.props.history}
           />
-          {this.renderContent()}
+          <Scroller>{this.renderContent()}</Scroller>
         </div>
       </PageWrapper>
     );

--- a/app/components/Settings.js
+++ b/app/components/Settings.js
@@ -1,7 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import { Button, Message, Header, Icon } from 'semantic-ui-react';
+import {
+  Button,
+  Message,
+  Header,
+  Icon,
+} from 'semantic-ui-react';
 import { getDefaultDolphinPath } from '../utils/settings';
 import PageHeader from './common/PageHeader';
 import ActionInput from './common/ActionInput';
@@ -69,8 +74,7 @@ export default class Settings extends Component {
       <div>
         Hello Linux friend! We cannot include a Dolphin build that is guaranteed
         to work on your distro. Please find the <b>Playback Dolphin Path</b>
-        &nbsp;option to configure.{' '}
-        <a href="https://discord.gg/KkhZQfR">Join the discord</a>
+        &nbsp;option to configure. <a href="https://discord.gg/KkhZQfR">Join the discord</a>
         &nbsp;if you have any questions.
       </div>
     );
@@ -109,37 +113,34 @@ export default class Settings extends Component {
   }
 
   renderISOVersionCheck() {
-    const validationState =
-      _.get(this.props.store, 'isoValidationState') || 'unknown';
+    const validationState = _.get(this.props.store, 'isoValidationState') || 'unknown';
 
     let icon, text, loading;
     switch (validationState) {
-    case 'success':
-      icon = 'check circle outline';
-      text = 'Valid';
+    case "success":
+      icon = "check circle outline";
+      text = "Valid";
       loading = false;
       break;
-    case 'fail':
-      icon = 'times circle outline';
-      text = 'Bad ISO';
+    case "fail":
+      icon = "times circle outline";
+      text = "Bad ISO";
       loading = false;
       break;
-    case 'validating':
-      icon = 'spinner';
-      text = 'Verifying';
+    case "validating":
+      icon = "spinner";
+      text = "Verifying";
       loading = true;
       break;
     default:
-      icon = 'question circle outline';
-      text = '';
+      icon = "question circle outline";
+      text = "";
       loading = false;
       break;
     }
-
+    
     return (
-      <div
-        className={`${styles['iso-version-check']} ${styles[validationState]}`}
-      >
+      <div className={`${styles['iso-version-check']} ${styles[validationState]}`}>
         <span className={styles['iso-verify-text']}>{text}</span>
         <Icon name={icon} fitted={true} loading={loading} size="large" />
       </div>
@@ -157,7 +158,7 @@ export default class Settings extends Component {
           label="Melee ISO File"
           description="The path to a NTSC Melee 1.02 ISO. Used for playing replay files"
           value={store.settings.isoPath}
-          error={isoValidationState === 'fail'}
+          error={isoValidationState === "fail"}
           onClick={this.props.browseFile}
           handlerParams={['isoPath']}
         />
@@ -178,7 +179,9 @@ export default class Settings extends Component {
 
     const platform = process.platform;
     if (platform === 'linux') {
-      inputs.push([this.renderPlaybackInstanceInput()]);
+      inputs.push([
+        this.renderPlaybackInstanceInput(),
+      ]);
     }
 
     return (
@@ -196,7 +199,9 @@ export default class Settings extends Component {
 
     const platform = process.platform;
     if (platform !== 'linux') {
-      inputs.push([this.renderPlaybackInstanceInput()]);
+      inputs.push([
+        this.renderPlaybackInstanceInput(),
+      ]);
     }
 
     if (_.isEmpty(inputs)) {
@@ -217,7 +222,7 @@ export default class Settings extends Component {
 
   renderPlaybackInstanceInput() {
     const store = this.props.store || {};
-
+    
     const platform = process.platform;
 
     // If on Linux, indicate the steps required
@@ -225,18 +230,9 @@ export default class Settings extends Component {
       <div>
         Linux users must build their own playback Dolphin instance
         <ul>
-          <li>
-            Use{' '}
-            <a href="https://github.com/project-slippi/Slippi-FM-installer">
-              installer script
-            </a>{' '}
-            to compile playback Dolphin
-          </li>
+          <li>Use <a href="https://github.com/project-slippi/Slippi-FM-installer">installer script</a> to compile playback Dolphin</li>
           <li>Move the compiled instance out of the build directory</li>
-          <li>
-            Set the field below to point to the directory that contains
-            dolphin-emu
-          </li>
+          <li>Set the field below to point to the directory that contains dolphin-emu</li>
         </ul>
       </div>
     );
@@ -249,8 +245,8 @@ export default class Settings extends Component {
     if (platform !== 'linux') {
       playbackDolphinDescription = (
         <div>
-          An instance of Dolphin for playing replays comes bundled with this
-          app. This setting allows you to configure a different instance.&nbsp;
+          An instance of Dolphin for playing replays comes bundled
+          with this app. This setting allows you to configure a different instance.&nbsp;
           <strong>Only modify if you know what you are doing.</strong>
         </div>
       );
@@ -293,7 +289,7 @@ export default class Settings extends Component {
           {this.renderConfigDolphin()}
         </SpacedGroup>
       </div>
-    );
+    )
   }
 
   renderContent() {

--- a/app/components/Settings.js
+++ b/app/components/Settings.js
@@ -16,6 +16,7 @@ import DismissibleMessage from './common/DismissibleMessage';
 import styles from './Settings.scss';
 import PageWrapper from './PageWrapper';
 import SpacedGroup from './common/SpacedGroup';
+import Scroller from './common/Scroller';
 
 const { app } = require('electron').remote;
 
@@ -34,6 +35,7 @@ export default class Settings extends Component {
     history: PropTypes.object.isRequired,
     store: PropTypes.object.isRequired,
     errors: PropTypes.object.isRequired,
+    topOffset: PropTypes.number.isRequired,
   };
 
   componentDidMount() {
@@ -317,7 +319,9 @@ export default class Settings extends Component {
             infoText={`App v${currentVersion}`}
             history={this.props.history}
           />
-          {this.renderContent()}
+          <Scroller topOffset={this.props.topOffset}>
+            {this.renderContent()}
+          </Scroller>
         </div>
       </PageWrapper>
     );

--- a/app/components/Settings.js
+++ b/app/components/Settings.js
@@ -35,7 +35,7 @@ export default class Settings extends Component {
     history: PropTypes.object.isRequired,
     store: PropTypes.object.isRequired,
     errors: PropTypes.object.isRequired,
-    topOffset: PropTypes.number.isRequired,
+    topNotifOffset: PropTypes.number.isRequired,
   };
 
   componentDidMount() {
@@ -319,7 +319,7 @@ export default class Settings extends Component {
             infoText={`App v${currentVersion}`}
             history={this.props.history}
           />
-          <Scroller topOffset={this.props.topOffset}>
+          <Scroller topOffset={this.props.topNotifOffset}>
             {this.renderContent()}
           </Scroller>
         </div>

--- a/app/components/common/Scroller.js
+++ b/app/components/common/Scroller.js
@@ -1,13 +1,18 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import styles from './Scroller.scss';
 
 export default class Scroller extends Component {
   static propTypes = {
     children: PropTypes.any.isRequired,
+    topOffset: PropTypes.number.isRequired,
   };
 
   render() {
-    return <div className={styles['scroller']}>{this.props.children}</div>;
+    const customStyles = {
+      overflowY: 'auto',
+      height: `calc(100vh - ${this.props.topOffset + 100}px)`,
+    };
+
+    return <div style={customStyles}>{this.props.children}</div>;
   }
 }

--- a/app/components/common/Scroller.js
+++ b/app/components/common/Scroller.js
@@ -1,11 +1,12 @@
-import _ from 'lodash';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styles from './Scroller.scss';
 
-const path = require('path');
-
 export default class Scroller extends Component {
+  static propTypes = {
+    children: PropTypes.any.isRequired,
+  };
+
   render() {
     return <div className={styles['scroller']}>{this.props.children}</div>;
   }

--- a/app/components/common/Scroller.js
+++ b/app/components/common/Scroller.js
@@ -1,0 +1,12 @@
+import _ from 'lodash';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import styles from './Scroller.scss';
+
+const path = require('path');
+
+export default class Scroller extends Component {
+  render() {
+    return <div className={styles['scroller']}>{this.props.children}</div>;
+  }
+}

--- a/app/components/common/Scroller.js
+++ b/app/components/common/Scroller.js
@@ -11,6 +11,7 @@ export default class Scroller extends Component {
     const customStyles = {
       overflowY: 'auto',
       height: `calc(100vh - ${this.props.topOffset + 100}px)`,
+      width: `calc(100% + 17px)`,
     };
 
     return <div style={customStyles}>{this.props.children}</div>;

--- a/app/components/common/Scroller.js
+++ b/app/components/common/Scroller.js
@@ -10,7 +10,7 @@ export default class Scroller extends Component {
   render() {
     const customStyles = {
       overflowY: 'auto',
-      height: `calc(100vh - ${this.props.topOffset + 100}px)`,
+      height: `calc(100vh - ${this.props.topOffset + 85}px)`,
       width: `calc(100% + 17px)`,
     };
 

--- a/app/components/common/Scroller.scss
+++ b/app/components/common/Scroller.scss
@@ -1,0 +1,4 @@
+.scroller {
+  overflow-y: auto;
+  height: calc(100vh - 150px);
+}

--- a/app/components/common/Scroller.scss
+++ b/app/components/common/Scroller.scss
@@ -1,4 +1,0 @@
-.scroller {
-  overflow-y: auto;
-  height: calc(100vh - 150px);
-}

--- a/app/components/stats/GameProfile.js
+++ b/app/components/stats/GameProfile.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import {
   Header,
   Segment,
-  Sticky,
   Image,
   Icon,
   Button,
@@ -26,6 +25,7 @@ import * as stageUtils from '../../utils/stages';
 import * as timeUtils from '../../utils/time';
 import * as playerUtils from '../../utils/players';
 import PageWrapper from '../PageWrapper';
+import Scroller from '../common/Scroller';
 
 export default class GameProfile extends Component {
   static propTypes = {
@@ -40,11 +40,6 @@ export default class GameProfile extends Component {
     // store data
     store: PropTypes.object.isRequired,
     errors: PropTypes.object.isRequired,
-    globalNotifs: PropTypes.object.isRequired,
-  };
-
-  state = {
-    isStatsStuck: false,
   };
 
   refStats = null;
@@ -79,7 +74,7 @@ export default class GameProfile extends Component {
 
   renderLoading() {
     const store = this.props.store || {};
-    
+
     return (
       <Loader
         className={styles['loader']}
@@ -192,12 +187,16 @@ export default class GameProfile extends Component {
       },
     ];
 
-    const consoleNick = _.get(this.props.store, ['game', 'metadata', 'consoleNick']);
+    const consoleNick = _.get(this.props.store, [
+      'game',
+      'metadata',
+      'consoleNick',
+    ]);
     if (consoleNick) {
       metadata.push({
         label: 'Console Name',
         content: consoleNick,
-      })
+      });
     }
 
     const metadataElements = metadata.map(details => (
@@ -232,48 +231,16 @@ export default class GameProfile extends Component {
   }
 
   renderStats() {
-    const handleStick = () => {
-      this.setState({
-        isStatsStuck: true,
-      });
-    };
-
-    const handleUnstick = () => {
-      this.setState({
-        isStatsStuck: false,
-      });
-    };
-
-    const statsSectionClasses = classNames(
-      {
-        [styles['stuck']]: this.state.isStatsStuck,
-      },
-      styles['stats-section']
-    );
-
-    const globalNotifHeightPx =
-      _.get(this.props.globalNotifs, ['activeNotif', 'heightPx']) || 0;
-
     return (
       <Segment basic={true}>
         {this.renderErrorModal()}
-        <Sticky
-          className={styles['sticky-names']}
-          offset={globalNotifHeightPx}
-          onStick={handleStick}
-          onUnstick={handleUnstick}
-          context={this.refStats}
-        >
-          <div className={styles['stats-player-header']}>
-            {this.renderMatchupDisplay()}
-            {this.renderGameDetails()}
+        <Scroller>
+          <div ref={this.setRefStats}>
+            {this.renderOverall()}
+            {this.renderStocks()}
+            {this.renderPunishes()}
           </div>
-        </Sticky>
-        <div ref={this.setRefStats} className={statsSectionClasses}>
-          {this.renderOverall()}
-          {this.renderStocks()}
-          {this.renderPunishes()}
-        </div>
+        </Scroller>
       </Segment>
     );
   }
@@ -401,6 +368,10 @@ export default class GameProfile extends Component {
       <PageWrapper history={this.props.history}>
         <div className="main-padding">
           <PageHeader icon="game" text="Game" history={this.props.history} />
+          <div className={styles['stats-player-header']}>
+            {this.renderMatchupDisplay()}
+            {this.renderGameDetails()}
+          </div>
           {this.renderContent()}
         </div>
       </PageWrapper>

--- a/app/components/stats/GameProfile.js
+++ b/app/components/stats/GameProfile.js
@@ -236,16 +236,16 @@ export default class GameProfile extends Component {
       120 + (_.get(this.props.globalNotifs, ['activeNotif', 'heightPx']) || 0); // 120 for game stats header
 
     return (
-      <Segment basic={true}>
-        {this.renderErrorModal()}
-        <Scroller topOffset={scrollerOffset}>
+      <Scroller topOffset={scrollerOffset}>
+        <Segment basic={true}>
+          {this.renderErrorModal()}
           <div ref={this.setRefStats}>
             {this.renderOverall()}
             {this.renderStocks()}
             {this.renderPunishes()}
           </div>
-        </Scroller>
-      </Segment>
+        </Segment>
+      </Scroller>
     );
   }
 

--- a/app/components/stats/GameProfile.js
+++ b/app/components/stats/GameProfile.js
@@ -40,7 +40,7 @@ export default class GameProfile extends Component {
     // store data
     store: PropTypes.object.isRequired,
     errors: PropTypes.object.isRequired,
-    topOffset: PropTypes.number.isRequired,
+    topNotifOffset: PropTypes.number.isRequired,
   };
 
   refStats = null;
@@ -233,8 +233,10 @@ export default class GameProfile extends Component {
 
   renderStats() {
 
+    const scrollerOffset = this.props.topNotifOffset + 120; // + 120 to account for game-specific header
+
     return (
-      <Scroller topOffset={this.props.topOffset}>
+      <Scroller topOffset={scrollerOffset}>
         <Segment basic={true}>
           {this.renderErrorModal()}
           <div ref={this.setRefStats}>

--- a/app/components/stats/GameProfile.js
+++ b/app/components/stats/GameProfile.js
@@ -40,7 +40,7 @@ export default class GameProfile extends Component {
     // store data
     store: PropTypes.object.isRequired,
     errors: PropTypes.object.isRequired,
-    globalNotifs: PropTypes.object.isRequired,
+    topOffset: PropTypes.number.isRequired,
   };
 
   refStats = null;
@@ -232,11 +232,9 @@ export default class GameProfile extends Component {
   }
 
   renderStats() {
-    const scrollerOffset =
-      120 + (_.get(this.props.globalNotifs, ['activeNotif', 'heightPx']) || 0); // 120 for game stats header
 
     return (
-      <Scroller topOffset={scrollerOffset}>
+      <Scroller topOffset={this.props.topOffset}>
         <Segment basic={true}>
           {this.renderErrorModal()}
           <div ref={this.setRefStats}>

--- a/app/components/stats/GameProfile.js
+++ b/app/components/stats/GameProfile.js
@@ -40,6 +40,7 @@ export default class GameProfile extends Component {
     // store data
     store: PropTypes.object.isRequired,
     errors: PropTypes.object.isRequired,
+    globalNotifs: PropTypes.object.isRequired,
   };
 
   refStats = null;
@@ -231,10 +232,13 @@ export default class GameProfile extends Component {
   }
 
   renderStats() {
+    const scrollerOffset =
+      120 + (_.get(this.props.globalNotifs, ['activeNotif', 'heightPx']) || 0); // 120 for game stats header
+
     return (
       <Segment basic={true}>
         {this.renderErrorModal()}
-        <Scroller>
+        <Scroller topOffset={scrollerOffset}>
           <div ref={this.setRefStats}>
             {this.renderOverall()}
             {this.renderStocks()}

--- a/app/components/stats/GameProfile.scss
+++ b/app/components/stats/GameProfile.scss
@@ -5,8 +5,8 @@ $header-height: 97px;
 .stats-player-header {
   position: relative;
   background: $background-lightest !important;
-  border-radius: 4px;
   width: calc(100% + 40px);
+  padding: 0 40px 0 40px;
   margin-left: -20px;
   z-index: 2; // needed for shadow to show up
   box-shadow: 2px 3px 5px rgba(0, 0, 0, 0.2);

--- a/app/components/stats/GameProfile.scss
+++ b/app/components/stats/GameProfile.scss
@@ -1,12 +1,11 @@
-@import "../../colors.global";
+@import '../../colors.global';
 
 $header-height: 97px;
 
 .stats-player-header {
   background: $background-lightest !important;
-  box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2);
-  margin: 0 -34px 0 -34px !important;
-  padding: 0 48px 0 48px !important;
+  border-radius: 4px;
+  box-shadow: 2px 3px 5px rgba(0, 0, 0, 0.2);
 
   .matchup-display {
     display: grid;
@@ -79,18 +78,11 @@ $header-height: 97px;
   }
 }
 
-.sticky-names {
-  z-index: 2;
-  position: relative;
-}
-
-.stats-section {
-  padding-top: 28px;
-
-  &.stuck {
-    margin-top: $header-height !important;
-  }
-}
+// .sticky-names {
+//   z-index: 2;
+//   position: relative;
+//   width: 100%;
+// }
 
 .vs-element {
   color: rgba(255, 255, 255, 0.5);
@@ -127,11 +119,11 @@ $header-height: 97px;
   margin: 0 !important;
   box-shadow: 3px 3px 2px rgba(0, 0, 0, 0.1) !important;
 
-  thead>tr>th {
+  thead > tr > th {
     background: $background-medium !important;
   }
 
-  tbody>tr>td {
+  tbody > tr > td {
     background: $background-light !important;
 
     &.category {

--- a/app/components/stats/GameProfile.scss
+++ b/app/components/stats/GameProfile.scss
@@ -3,8 +3,12 @@
 $header-height: 97px;
 
 .stats-player-header {
+  position: relative;
   background: $background-lightest !important;
   border-radius: 4px;
+  width: calc(100% + 40px);
+  margin-left: -20px;
+  z-index: 2; // needed for shadow to show up
   box-shadow: 2px 3px 5px rgba(0, 0, 0, 0.2);
 
   .matchup-display {

--- a/app/components/stats/GameProfile.scss
+++ b/app/components/stats/GameProfile.scss
@@ -6,7 +6,7 @@ $header-height: 97px;
   position: relative;
   background: $background-lightest !important;
   width: calc(100% + 40px);
-  padding: 0 40px 0 40px;
+  padding: 0 40px 0 34px;
   margin-left: -20px;
   z-index: 2; // needed for shadow to show up
   box-shadow: 2px 3px 5px rgba(0, 0, 0, 0.2);
@@ -42,7 +42,6 @@ $header-height: 97px;
 
     .play-button {
       justify-self: end;
-      margin-right: 14px;
     }
   }
 

--- a/app/components/stats/GameProfile.scss
+++ b/app/components/stats/GameProfile.scss
@@ -78,12 +78,6 @@ $header-height: 97px;
   }
 }
 
-// .sticky-names {
-//   z-index: 2;
-//   position: relative;
-//   width: 100%;
-// }
-
 .vs-element {
   color: rgba(255, 255, 255, 0.5);
   line-height: 0.8;
@@ -119,11 +113,11 @@ $header-height: 97px;
   margin: 0 !important;
   box-shadow: 3px 3px 2px rgba(0, 0, 0, 0.1) !important;
 
-  thead > tr > th {
+  thead>tr>th {
     background: $background-medium !important;
   }
 
-  tbody > tr > td {
+  tbody>tr>td {
     background: $background-light !important;
 
     &.category {

--- a/app/containers/ConsolePage.js
+++ b/app/containers/ConsolePage.js
@@ -9,6 +9,7 @@ function mapStateToProps(state) {
   return {
     store: state.console,
     errors: state.errors,
+    topOffset: _.get(state.globalNotifs, ['activeNotif', 'heightPx']) || 0,
   };
 }
 

--- a/app/containers/ConsolePage.js
+++ b/app/containers/ConsolePage.js
@@ -9,7 +9,7 @@ function mapStateToProps(state) {
   return {
     store: state.console,
     errors: state.errors,
-    topOffset: _.get(state.globalNotifs, ['activeNotif', 'heightPx']) || 0,
+    topNotifOffset: _.get(state.notifs, ['activeNotif', 'heightPx']) || 0,
   };
 }
 

--- a/app/containers/FileLoaderPage.js
+++ b/app/containers/FileLoaderPage.js
@@ -10,7 +10,7 @@ function mapStateToProps(state) {
   return {
     store: state.fileLoader,
     errors: state.errors,
-    topOffset: _.get(state.globalNotifs, ['activeNotif', 'heightPx']) || 0,
+    topNotifOffset: _.get(state.notifs, ['activeNotif', 'heightPx']) || 0,
   };
 }
 

--- a/app/containers/FileLoaderPage.js
+++ b/app/containers/FileLoaderPage.js
@@ -10,7 +10,7 @@ function mapStateToProps(state) {
   return {
     store: state.fileLoader,
     errors: state.errors,
-    globalNotifs: state.notifs,
+    topOffset: _.get(state.globalNotifs, ['activeNotif', 'heightPx']) || 0,
   };
 }
 

--- a/app/containers/GameProfilePage.js
+++ b/app/containers/GameProfilePage.js
@@ -9,7 +9,7 @@ function mapStateToProps(state) {
   return {
     store: state.game,
     errors: state.errors,
-    topOffset: _.get(state.globalNotifs, ['activeNotif', 'heightPx']) || 0,
+    topNotifOffset: _.get(state.notifs, ['activeNotif', 'heightPx']) || 0,
   };
 }
 

--- a/app/containers/GameProfilePage.js
+++ b/app/containers/GameProfilePage.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import GameProfile from '../components/stats/GameProfile';
@@ -8,7 +9,7 @@ function mapStateToProps(state) {
   return {
     store: state.game,
     errors: state.errors,
-    globalNotifs: state.notifs,
+    topOffset: _.get(state.globalNotifs, ['activeNotif', 'heightPx']) || 0,
   };
 }
 

--- a/app/containers/SettingsPage.js
+++ b/app/containers/SettingsPage.js
@@ -9,7 +9,7 @@ function mapStateToProps(state) {
   return {
     store: state.settings,
     errors: state.errors,
-    topOffset: _.get(state.globalNotifs, ['activeNotif', 'heightPx']) || 0,
+    topNotifOffset: _.get(state.notifs, ['activeNotif', 'heightPx']) || 0,
   };
 }
 

--- a/app/containers/SettingsPage.js
+++ b/app/containers/SettingsPage.js
@@ -9,6 +9,7 @@ function mapStateToProps(state) {
   return {
     store: state.settings,
     errors: state.errors,
+    topOffset: _.get(state.globalNotifs, ['activeNotif', 'heightPx']) || 0,
   };
 }
 


### PR DESCRIPTION
Update: 2nd May

based on feedback from fizzi:

- Scrollbar is now aligned with right edge
- Space below scrollbar on replays menu removed
- Settings and console page now scroll as well

Screens:
![image](https://user-images.githubusercontent.com/28009867/57068687-64b09b00-6cca-11e9-9f50-a3ab7a1f6b63.png)
![image](https://user-images.githubusercontent.com/28009867/57068702-6a0de580-6cca-11e9-8f2a-3385005b40e1.png)


=========================

A lot of style changes were made by PrettierJS (e.g double quotes to singles) - It seems to have happened a lot but pretty sure its based off the rules in .prettierrc so I have left them in the PR. Let me know if this is a mistake

- Now works even with global notification (e.g new version message). 
- Sadly still requires some of the same hackery RE checking for notifications
- Tested on replay list + stats screen
- Screenshots below

![image](https://user-images.githubusercontent.com/28009867/56379086-cb33b480-6206-11e9-807b-47e39952222c.png)
![image](https://user-images.githubusercontent.com/28009867/56379131-e69ebf80-6206-11e9-8014-55ec24707f26.png)
![image](https://user-images.githubusercontent.com/28009867/56379120-df77b180-6206-11e9-9974-2564cb17fd59.png)

