### PR TITLE
Update OBS Autoswitch

### DIFF
--- a/app/domain/SlpFileWriter.js
+++ b/app/domain/SlpFileWriter.js
@@ -51,8 +51,7 @@ export default class SlpFileWriter {
     this.obsPassword = settings.obsPassword;
   }
 
-  getSceneSources = async (data) => {
-    console.log(data);
+  getSceneSources = async (data = null) => { // eslint-disable-line
     const res = await this.obs.send("GetSceneList");
     const scenes = res.scenes || [];
     const pairs = _.flatMap(scenes, (scene) => {
@@ -60,7 +59,6 @@ export default class SlpFileWriter {
       return _.map(sources, (source) => ({scene: scene.name, source: source.name}));
     });
     this.obsPairs = _.filter(pairs, (pair) => pair.source === this.obsSourceName);
-    console.log(this.obsPairs);
   }
 
   async connectOBS() {
@@ -79,9 +77,8 @@ export default class SlpFileWriter {
     this.statusOutput.status = value;
     console.log(`Status changed: ${value}`);
     _.forEach(this.obsPairs, (pair) => {
-      const res = this.obs.send("SetSceneItemProperties", 
+      this.obs.send("SetSceneItemProperties", 
         {"scene-name": pair.scene, "item": this.obsSourceName, "visible": value});
-      console.log(res);
     });
   }
 


### PR DESCRIPTION
* Rewrite how we store the pairs so we spend less time looking for the sources in the array
* Update the pairs at the end of the game so users don't have to disconnect and reconnect to auto switch new SceneItems (this is a stopgap until Palakis releases the next version of OBS Websocket that supports better events)
* Update the timer at game end to 700ms and the frame we start on to -60