### PR TITLE
Add game directory to Dolphin paths

### DIFF
--- a/app/actions/settings.js
+++ b/app/actions/settings.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import crypto from 'crypto';
 import ini from 'ini';
 import path from 'path';
+import log from 'electron-log';
 import electronSettings from 'electron-settings';
 
 import { displayError } from './error';
@@ -80,13 +81,17 @@ export function browseFile(field) {
       default:
         throw new Error("The current platform is not supported");
       }
-      const iniPath = path.join(dolphinPath, "User", "Config", "Dolphin.ini");
-      const dolphinINI = ini.parse(fs.readFileSync(iniPath, 'utf-8'));
-      dolphinINI.General.ISOPath0 = fileDir;
-      const numPaths = dolphinINI.General.ISOPaths;
-      dolphinINI.General.ISOPaths = numPaths !== "0" ? numPaths : "1";
-      const newINI = ini.encode(dolphinINI);
-      fs.writeFileSync(iniPath, newINI);
+      try {
+        const iniPath = path.join(dolphinPath, "User", "Config", "Dolphin.ini");
+        const dolphinINI = ini.parse(fs.readFileSync(iniPath, 'utf-8'));
+        dolphinINI.General.ISOPath0 = fileDir;
+        const numPaths = dolphinINI.General.ISOPaths;
+        dolphinINI.General.ISOPaths = numPaths !== "0" ? numPaths : "1";
+        const newINI = ini.encode(dolphinINI);
+        fs.writeFileSync(iniPath, newINI);
+      } catch (err) {
+        log.warn(`Failed to update the dolphin paths\n${err}`)
+      }
     }
   };
 }

--- a/app/actions/settings.js
+++ b/app/actions/settings.js
@@ -1,6 +1,8 @@
 import fs from 'fs-extra';
 import _ from 'lodash';
 import crypto from 'crypto';
+import ini from 'ini';
+import path from 'path';
 
 import { displayError } from './error';
 
@@ -59,6 +61,15 @@ export function browseFile(field) {
     // Maybe this should be done as some kind of callback or something... but this works
     if (field === "isoPath") {
       validateISO()(dispatch, getState);
+      const fileDir = path.dirname(filePath);
+      const iniPath = path.join(process.env.APPDATA, "Slippi Desktop App", 
+        "dolphin", "User", "Config", "Dolphin.ini");
+      const dolphinINI = ini.parse(fs.readFileSync(iniPath, 'utf-8'));
+      dolphinINI.General.ISOPath0 = fileDir;
+      const numPaths = dolphinINI.General.ISOPaths;
+      dolphinINI.General.ISOPaths = numPaths !== "0" ? numPaths : "1";
+      const newINI = ini.encode(dolphinINI);
+      fs.writeFileSync(iniPath, newINI);
     }
   };
 }

--- a/app/actions/settings.js
+++ b/app/actions/settings.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import crypto from 'crypto';
 import ini from 'ini';
 import path from 'path';
+import electronSettings from 'electron-settings';
 
 import { displayError } from './error';
 
@@ -62,8 +63,21 @@ export function browseFile(field) {
     if (field === "isoPath") {
       validateISO()(dispatch, getState);
       const fileDir = path.dirname(filePath);
-      const iniPath = path.join(app.getPath("userData"),
-        "dolphin", "User", "Config", "Dolphin.ini");
+      const platform = process.platform;
+      const isDev = process.env.NODE_ENV === "development";
+      const storedDolphinPath = electronSettings.get('settings.playbackDolphinPath');
+      let dolphinPath = storedDolphinPath || path.join(app.getPath("appData"), "Slippi Desktop App", "dolphin");
+      switch (platform) {
+      case "darwin": // osx
+        dolphinPath = isDev ? "./app/dolphin-dev/osx" : dolphinPath;
+        break;
+      case "win32": // windows
+        dolphinPath = isDev ? "./app/dolphin-dev/windows" : dolphinPath;
+        break;
+      default:
+        throw new Error("The current platform is not supported");
+      }
+      const iniPath = path.join(dolphinPath, "User", "Config", "Dolphin.ini");
       const dolphinINI = ini.parse(fs.readFileSync(iniPath, 'utf-8'));
       dolphinINI.General.ISOPath0 = fileDir;
       const numPaths = dolphinINI.General.ISOPaths;

--- a/app/actions/settings.js
+++ b/app/actions/settings.js
@@ -6,7 +6,7 @@ import path from 'path';
 
 import { displayError } from './error';
 
-const { dialog } = require('electron').remote;
+const { dialog, app } = require('electron').remote;
 
 export const SELECT_FOLDER = 'SELECT_FOLDER';
 export const SELECT_FILE = 'SELECT_FILE';
@@ -62,7 +62,7 @@ export function browseFile(field) {
     if (field === "isoPath") {
       validateISO()(dispatch, getState);
       const fileDir = path.dirname(filePath);
-      const iniPath = path.join(process.env.APPDATA, "Slippi Desktop App", 
+      const iniPath = path.join(app.getPath("userData"), "Slippi Desktop App", 
         "dolphin", "User", "Config", "Dolphin.ini");
       const dolphinINI = ini.parse(fs.readFileSync(iniPath, 'utf-8'));
       dolphinINI.General.ISOPath0 = fileDir;

--- a/app/actions/settings.js
+++ b/app/actions/settings.js
@@ -67,12 +67,15 @@ export function browseFile(field) {
       const isDev = process.env.NODE_ENV === "development";
       const storedDolphinPath = electronSettings.get('settings.playbackDolphinPath');
       let dolphinPath = storedDolphinPath || path.join(app.getPath("appData"), "Slippi Desktop App", "dolphin");
+      // Handle the dolphin INI file being in different paths per platform
       switch (platform) {
       case "darwin": // osx
         dolphinPath = isDev ? "./app/dolphin-dev/osx/Dolphin.app/Contents/Resources" : path.join(dolphinPath, "Dolphin.app/Contents/Resources");
         break;
       case "win32": // windows
         dolphinPath = isDev ? "./app/dolphin-dev/windows" : dolphinPath;
+        break;
+      case "linux":
         break;
       default:
         throw new Error("The current platform is not supported");

--- a/app/actions/settings.js
+++ b/app/actions/settings.js
@@ -62,7 +62,7 @@ export function browseFile(field) {
     if (field === "isoPath") {
       validateISO()(dispatch, getState);
       const fileDir = path.dirname(filePath);
-      const iniPath = path.join(app.getPath("userData"), "Slippi Desktop App", 
+      const iniPath = path.join(app.getPath("userData"),
         "dolphin", "User", "Config", "Dolphin.ini");
       const dolphinINI = ini.parse(fs.readFileSync(iniPath, 'utf-8'));
       dolphinINI.General.ISOPath0 = fileDir;

--- a/app/actions/settings.js
+++ b/app/actions/settings.js
@@ -69,7 +69,7 @@ export function browseFile(field) {
       let dolphinPath = storedDolphinPath || path.join(app.getPath("appData"), "Slippi Desktop App", "dolphin");
       switch (platform) {
       case "darwin": // osx
-        dolphinPath = isDev ? "./app/dolphin-dev/osx" : dolphinPath;
+        dolphinPath = isDev ? "./app/dolphin-dev/osx/Dolphin.app/Contents/Resources" : path.join(dolphinPath, "Dolphin.app/Contents/Resources");
         break;
       case "win32": // windows
         dolphinPath = isDev ? "./app/dolphin-dev/windows" : dolphinPath;

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -57,16 +57,15 @@ if (isoPath){
   const fileDir = path.dirname(isoPath);
   const storedDolphinPath = electronSettings.get('settings.playbackDolphinPath');
   let dolphinPath = storedDolphinPath || path.join(appDataPath, "Slippi Desktop App", "dolphin");
-  // Here we are going to build the platform-specific commands required to launch
-  // dolphin from the command line with the correct game
-  // When in development mode, use the build-specific dolphin version
-  // In production mode, only the build from the correct platform should exist
+  // Handle the dolphin INI file being in different paths per platform
   switch (platform) {
   case "darwin": // osx
     dolphinPath = isDev ? "./app/dolphin-dev/osx/Dolphin.app/Contents/Resources" : path.join(dolphinPath, "Dolphin.app/Contents/Resources");
     break;
   case "win32": // windows
     dolphinPath = isDev ? "./app/dolphin-dev/windows" : dolphinPath;
+    break;
+  case "linux":
     break;
   default:
     throw new Error("The current platform is not supported");

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -91,6 +91,7 @@ if (isProd && (platform === "win32" || platform === "darwin")) {
 // Add game path to Playback Dolphin
 const isoPath = electronSettings.get("settings.isoPath");
 if (isoPath){
+  log.info("ISO path found");
   const fileDir = path.dirname(isoPath);
   const storedDolphinPath = electronSettings.get('settings.playbackDolphinPath');
   let dolphinPath = storedDolphinPath || path.join(appDataPath, "Slippi Desktop App", "dolphin");
@@ -107,13 +108,17 @@ if (isoPath){
   default:
     throw new Error("The current platform is not supported");
   }
-  const iniPath = path.join(dolphinPath, "User", "Config", "Dolphin.ini");
-  const dolphinINI = ini.parse(fs.readFileSync(iniPath, 'utf-8'));
-  dolphinINI.General.ISOPath0 = fileDir;
-  const numPaths = dolphinINI.General.ISOPaths;
-  dolphinINI.General.ISOPaths = numPaths !== "0" ? numPaths : "1";
-  const newINI = ini.encode(dolphinINI);
-  fs.writeFileSync(iniPath, newINI);
+  try {
+    const iniPath = path.join(dolphinPath, "User", "Config", "Dolphin.ini");
+    const dolphinINI = ini.parse(fs.readFileSync(iniPath, 'utf-8'));
+    dolphinINI.General.ISOPath0 = fileDir;
+    const numPaths = dolphinINI.General.ISOPaths;
+    dolphinINI.General.ISOPaths = numPaths !== "0" ? numPaths : "1";
+    const newINI = ini.encode(dolphinINI);
+    fs.writeFileSync(iniPath, newINI);
+  } catch (err) {
+    log.warn(`Failed to update the dolphin paths\n${err}`)
+  }
 }
 
 // Copy settings from when the app was called Slippi Launcher

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -19,6 +19,7 @@ import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
 import path from 'path';
 import fs from 'fs-extra';
+import ini from 'ini';
 import MenuBuilder from './menu';
 
 // Set up AppUpdater
@@ -28,6 +29,10 @@ autoUpdater.autoInstallOnAppQuit = false;
 log.info('App starting...');
 
 const slippiProtocol = "slippi";
+const platform = process.platform;
+const appDataPath = app.getPath("appData");
+const isProd = process.env.NODE_ENV === 'production';
+const isDev = process.env.NODE_ENV === "development";
 
 let mainWindow = null;
 let didFinishLoad = false;
@@ -46,10 +51,36 @@ if (
   require('electron-debug')();
 }
 
-const isProd = process.env.NODE_ENV === 'production';
+// Add game path to Playback Dolphin
+const isoPath = electronSettings.get("settings.isoPath");
+if (isoPath){
+  const fileDir = path.dirname(isoPath);
+  const storedDolphinPath = electronSettings.get('settings.playbackDolphinPath');
+  let dolphinPath = storedDolphinPath || path.join(appDataPath, "Slippi Desktop App", "dolphin");
+  // Here we are going to build the platform-specific commands required to launch
+  // dolphin from the command line with the correct game
+  // When in development mode, use the build-specific dolphin version
+  // In production mode, only the build from the correct platform should exist
+  switch (platform) {
+  case "darwin": // osx
+    dolphinPath = isDev ? "./app/dolphin-dev/osx" : dolphinPath;
+    break;
+  case "win32": // windows
+    dolphinPath = isDev ? "./app/dolphin-dev/windows" : dolphinPath;
+    break;
+  default:
+    throw new Error("The current platform is not supported");
+  }
+  const iniPath = path.join(dolphinPath, "User", "Config", "Dolphin.ini");
+  const dolphinINI = ini.parse(fs.readFileSync(iniPath, 'utf-8'));
+  dolphinINI.General.ISOPath0 = fileDir;
+  const numPaths = dolphinINI.General.ISOPaths;
+  dolphinINI.General.ISOPaths = numPaths !== "0" ? numPaths : "1";
+  const newINI = ini.encode(dolphinINI);
+  fs.writeFileSync(iniPath, newINI);
+}
 
 // Copy settings from when the app was called Slippi Launcher
-const appDataPath = app.getPath("appData");
 const prevVersion = electronSettings.get('previousVersion');
 if (isProd && !prevVersion) {
   // On the very first install of the "Slippi Desktop App", let's transfer over settings from
@@ -74,7 +105,6 @@ if (isProd && !prevVersion) {
   }
 }
 
-const platform = process.platform;
 if (isProd && (platform === "win32" || platform === "darwin")) {
   log.info("Checking if Dolphin path has been moved...");
 

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -63,7 +63,7 @@ if (isoPath){
   // In production mode, only the build from the correct platform should exist
   switch (platform) {
   case "darwin": // osx
-    dolphinPath = isDev ? "./app/dolphin-dev/osx" : dolphinPath;
+    dolphinPath = isDev ? "./app/dolphin-dev/osx/Dolphin.app/Contents/Resources" : path.join(dolphinPath, "Dolphin.app/Contents/Resources");
     break;
   case "win32": // windows
     dolphinPath = isDev ? "./app/dolphin-dev/windows" : dolphinPath;

--- a/package.json
+++ b/package.json
@@ -264,6 +264,7 @@
     "electron-updater": "^4.0.6",
     "fs-extra": "^7.0.1",
     "history": "^4.7.2",
+    "ini": "^1.3.5",
     "lodash": "^4.17.11",
     "moment": "^2.23.0",
     "obs-websocket-js": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6748,7 +6748,7 @@ inherits@2.0.1:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
   integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
-ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==


### PR DESCRIPTION
Working on windows. Updates the paths on start up or if the user selects an ISO.

Partially tested on macOS