### PR TITLE
Fix visual regressions from PR #17

### DIFF
--- a/app/app.global.scss
+++ b/app/app.global.scss
@@ -12,6 +12,10 @@ body {
   overflow: hidden;
 }
 
+i{
+  overflow: visible;
+}
+
 ul {
   margin: 0;
   padding-left: 20px;

--- a/app/app.global.scss
+++ b/app/app.global.scss
@@ -12,7 +12,7 @@ body {
   overflow: hidden;
 }
 
-i{
+i, form *{
   overflow: visible;
 }
 


### PR DESCRIPTION
Two small regressions from PR #17  that metonym contacted me about.

- Icons on the Console page where cut off (e.g Edit, Delete, Connect)
- Horizontal dividers on "advanced settings" while editing a connection had gone missing

Both are fixed in this PR. screenshots below:

![image](https://user-images.githubusercontent.com/28009867/57310787-53102e80-70e2-11e9-8938-c5a2c62ff0a2.png)
![image](https://user-images.githubusercontent.com/28009867/57310800-5a373c80-70e2-11e9-88f3-dc6bf9c64f83.png)
