### PR TITLE
Hide game profile header while a game is loading

### DIFF
--- a/app/components/stats/GameProfile.js
+++ b/app/components/stats/GameProfile.js
@@ -105,6 +105,19 @@ export default class GameProfile extends Component {
     );
   }
 
+  renderGameProfileHeader() {
+    const isLoading = _.get(this.props.store, 'isLoading') || false;
+
+    return isLoading
+      ? <React.Fragment></React.Fragment>
+      : (
+        <div className={styles['stats-player-header']}>
+          {this.renderMatchupDisplay()}
+          {this.renderGameDetails()}
+        </div>
+      );
+  }
+
   renderMatchupDisplay() {
     return (
       <div className={styles['matchup-display']}>
@@ -232,7 +245,6 @@ export default class GameProfile extends Component {
   }
 
   renderStats() {
-
     const scrollerOffset = this.props.topNotifOffset + 120; // + 120 to account for game-specific header
 
     return (
@@ -372,10 +384,7 @@ export default class GameProfile extends Component {
       <PageWrapper history={this.props.history}>
         <div className="main-padding">
           <PageHeader icon="game" text="Game" history={this.props.history} />
-          <div className={styles['stats-player-header']}>
-            {this.renderMatchupDisplay()}
-            {this.renderGameDetails()}
-          </div>
+          {this.renderGameProfileHeader()}
           {this.renderContent()}
         </div>
       </PageWrapper>


### PR DESCRIPTION
Before these changes, when selecting a game it would show you the previous game profile's header or if there was no previous it would show an empty header while loading, instead of just displaying nothing.

Before:
![before](https://user-images.githubusercontent.com/37189243/58440565-dea92980-80a8-11e9-8ff2-abd7aa3cef38.png)

After:
![after](https://user-images.githubusercontent.com/37189243/58440563-d5b85800-80a8-11e9-9dc4-39a17efe4362.png)
