### PR TITLE
Update App menu bar with more relevant links

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -42,49 +42,14 @@ export default class MenuBuilder {
 
   buildDarwinTemplate() {
     const subMenuAbout = {
-      label: 'Electron',
+      label: 'Slippi Desktop App',
       submenu: [
-        {
-          label: 'About ElectronReact',
-          selector: 'orderFrontStandardAboutPanel:',
-        },
-        { type: 'separator' },
-        { label: 'Services', submenu: [] },
-        { type: 'separator' },
-        {
-          label: 'Hide ElectronReact',
-          accelerator: 'Command+H',
-          selector: 'hide:',
-        },
-        {
-          label: 'Hide Others',
-          accelerator: 'Command+Shift+H',
-          selector: 'hideOtherApplications:',
-        },
-        { label: 'Show All', selector: 'unhideAllApplications:' },
-        { type: 'separator' },
         {
           label: 'Quit',
           accelerator: 'Command+Q',
           click: () => {
             app.quit();
           },
-        },
-      ],
-    };
-    const subMenuEdit = {
-      label: 'Edit',
-      submenu: [
-        { label: 'Undo', accelerator: 'Command+Z', selector: 'undo:' },
-        { label: 'Redo', accelerator: 'Shift+Command+Z', selector: 'redo:' },
-        { type: 'separator' },
-        { label: 'Cut', accelerator: 'Command+X', selector: 'cut:' },
-        { label: 'Copy', accelerator: 'Command+C', selector: 'copy:' },
-        { label: 'Paste', accelerator: 'Command+V', selector: 'paste:' },
-        {
-          label: 'Select All',
-          accelerator: 'Command+A',
-          selector: 'selectAll:',
         },
       ],
     };
@@ -143,29 +108,23 @@ export default class MenuBuilder {
       label: 'Help',
       submenu: [
         {
-          label: 'Learn More',
+          label: 'slippi.gg',
           click: function() {
-            shell.openExternal('http://electron.atom.io');
+            shell.openExternal('https://slippi.gg');
           },
         },
         {
-          label: 'Documentation',
+          label: 'GitHub',
           click: function() {
             shell.openExternal(
-              'https://github.com/atom/electron/tree/master/docs#readme'
+              'https://github.com/project-slippi/project-slippi'
             );
           },
         },
         {
-          label: 'Community Discussions',
+          label: 'Discord',
           click: function() {
-            shell.openExternal('https://discuss.atom.io/c/electron');
-          },
-        },
-        {
-          label: 'Search Issues',
-          click: function() {
-            shell.openExternal('https://github.com/atom/electron/issues');
+            shell.openExternal('https://discord.gg/pPfEaW5');
           },
         },
       ],
@@ -174,27 +133,11 @@ export default class MenuBuilder {
     const subMenuView =
       process.env.NODE_ENV === 'development' ? subMenuViewDev : subMenuViewProd;
 
-    return [subMenuAbout, subMenuEdit, subMenuView, subMenuWindow, subMenuHelp];
+    return [subMenuAbout, subMenuView, subMenuWindow, subMenuHelp];
   }
 
   buildDefaultTemplate() {
     const templateDefault = [
-      {
-        label: '&File',
-        submenu: [
-          {
-            label: '&Open',
-            accelerator: 'Ctrl+O',
-          },
-          {
-            label: '&Close',
-            accelerator: 'Ctrl+W',
-            click: () => {
-              this.mainWindow.close();
-            },
-          },
-        ],
-      },
       {
         label: '&View',
         submenu:
@@ -240,29 +183,23 @@ export default class MenuBuilder {
         label: 'Help',
         submenu: [
           {
-            label: 'Learn More',
+            label: 'slippi.gg',
             click: function() {
-              shell.openExternal('http://electron.atom.io');
+              shell.openExternal('http://slippi.gg');
             },
           },
           {
-            label: 'Documentation',
+            label: 'GitHub',
             click: function() {
               shell.openExternal(
-                'https://github.com/atom/electron/tree/master/docs#readme'
+                'https://github.com/project-slippi/project-slippi'
               );
             },
           },
           {
-            label: 'Community Discussions',
+            label: 'Discord',
             click: function() {
-              shell.openExternal('https://discuss.atom.io/c/electron');
-            },
-          },
-          {
-            label: 'Search Issues',
-            click: function() {
-              shell.openExternal('https://github.com/atom/electron/issues');
+              shell.openExternal('https://discord.gg/pPfEaW5');
             },
           },
         ],

--- a/app/menu.js
+++ b/app/menu.js
@@ -57,51 +57,12 @@ export default class MenuBuilder {
       label: 'View',
       submenu: [
         {
-          label: 'Reload',
-          accelerator: 'Command+R',
-          click: () => {
-            this.mainWindow.webContents.reload();
-          },
-        },
-        {
-          label: 'Toggle Full Screen',
-          accelerator: 'Ctrl+Command+F',
-          click: () => {
-            this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen());
-          },
-        },
-        {
           label: 'Toggle Developer Tools',
           accelerator: 'Alt+Command+I',
           click: () => {
             this.mainWindow.toggleDevTools();
           },
         },
-      ],
-    };
-    const subMenuViewProd = {
-      label: 'View',
-      submenu: [
-        {
-          label: 'Toggle Full Screen',
-          accelerator: 'Ctrl+Command+F',
-          click: () => {
-            this.mainWindow.setFullScreen(!this.mainWindow.isFullScreen());
-          },
-        },
-      ],
-    };
-    const subMenuWindow = {
-      label: 'Window',
-      submenu: [
-        {
-          label: 'Minimize',
-          accelerator: 'Command+M',
-          selector: 'performMiniaturize:',
-        },
-        { label: 'Close', accelerator: 'Command+W', selector: 'performClose:' },
-        { type: 'separator' },
-        { label: 'Bring All to Front', selector: 'arrangeInFront:' },
       ],
     };
     const subMenuHelp = {
@@ -130,10 +91,10 @@ export default class MenuBuilder {
       ],
     };
 
-    const subMenuView =
-      process.env.NODE_ENV === 'development' ? subMenuViewDev : subMenuViewProd;
+    const menus =
+      process.env.NODE_ENV === 'development' ? [subMenuAbout, subMenuViewDev, subMenuHelp] : [subMenuAbout, subMenuHelp];
 
-    return [subMenuAbout, subMenuView, subMenuWindow, subMenuHelp];
+    return menus;
   }
 
   buildDefaultTemplate() {


### PR DESCRIPTION
Removed useless Electron stuff and added links for slippi.gg, Discord, and GitHub

Tested on Windows (works fine) and macOS (works fine)