### PR TITLE
Add permissive licensing

### DIFF
--- a/app/domain/ConsoleCommunication.js
+++ b/app/domain/ConsoleCommunication.js
@@ -1,3 +1,24 @@
+/*
+
+Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+*/
+
+
 import { decode, encode } from "@shelacek/ubjson";
 
 export const types = {

--- a/app/domain/ConsoleConnection.js
+++ b/app/domain/ConsoleConnection.js
@@ -1,3 +1,24 @@
+/*
+
+Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+*/
+
+
 import net from 'net';
 import _ from 'lodash';
 import log from 'electron-log';

--- a/app/domain/SlpFileWriter.js
+++ b/app/domain/SlpFileWriter.js
@@ -1,3 +1,30 @@
+/*
+
+MIT License
+
+Copyright (c) 2017 jlaferri
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+
 import net from 'net';
 import _ from 'lodash';
 import fs from 'fs-extra';


### PR DESCRIPTION
This PR adds permissive licensing for certain files in `app/domain`.

It gives the LGPL license to:
* `ConsoleCommunication.js`
* `ConsoleConnection.js`

This allows the code to be linked/bundled in other libraries without enforcing the restrictions of GPLv3, provided no changes were made to the source code.

It gives the MIT license to:
* `SlpFileWriter.js`

The reasoning for the MIT license for the `SlpFileWriter.js` is because the Slippi spec is open and public and allows potentially merging with the existing `slp-parser-js` library released under MIT.