### PR TITLE
Add play all function

### DIFF
--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -189,6 +189,11 @@ export default class FileLoader extends Component {
     });
   }
 
+  queueAllFiles = () => {
+    const filteredFiles = this.processFiles(this.state.files)
+    this.props.queueFiles(_.reverse(filteredFiles));
+  }
+
   renderGlobalError() {
     const errors = this.props.errors || {};
     const errorKey = 'fileLoader-global';
@@ -365,10 +370,14 @@ export default class FileLoader extends Component {
   }
 
   renderQueueButtons() {
-    if (this.state.selections.length === 0) {
-      return;
-    }
-    return (
+    return this.state.selections.length === 0 ? (
+      <div className={styles['queue-buttons']}>
+        <Button onClick={this.queueAllFiles}>
+          <Icon name="play circle" />
+          Play all
+        </Button>
+      </div>
+    ) : (
       <div className={styles['queue-buttons']}>
         <Button onClick={this.queueFiles}>
           <Icon name="play circle" />


### PR DESCRIPTION
Essentially kept the "Play All" button always displaying and it enqueues all files (post filtering) for replay. Would like to know if there are any preferences on playback order, as I have to reverse the file array in order to play from oldest to newest as specified by the [trello](https://trello.com/c/Fxes0Izs/118-play-all-button-to-play-all-files-in-a-folder-in-a-row). I can see this having performance issues on a large number of replays and not really giving us significant functionality in return.

![image](https://user-images.githubusercontent.com/9536605/76174542-4636ee00-617e-11ea-8f52-c825c86b688c.png)
