### PR TITLE
Add select all functionality

### DIFF
--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -137,6 +137,11 @@ export default class FileLoader extends Component {
     });
   }
 
+  queueAllFiles = () => {
+    const filteredFiles = this.processFiles(this.state.files)
+    this.props.queueFiles(_.reverse(filteredFiles));
+  }
+
   renderGlobalError() {
     const errors = this.props.errors || {};
     const errorKey = 'fileLoader-global';
@@ -317,10 +322,14 @@ export default class FileLoader extends Component {
   }
 
   renderQueueButtons() {
-    if (this.state.selections.length === 0) {
-      return;
-    }
-    return (
+    return this.state.selections.length === 0 ? (
+      <div className={styles['queue-buttons']}>
+        <Button onClick={this.queueAllFiles}>
+          <Icon name="play circle" />
+          Play all
+        </Button>
+      </div>
+    ) : (
       <div className={styles['queue-buttons']}>
         <Button onClick={this.queueFiles}>
           <Icon name="play circle" />

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -346,9 +346,9 @@ export default class FileLoader extends Component {
     // Generate header row
     const headerRow = (
       <Table.Row>
-        <Table.HeaderCell>{selectAllIcon}</Table.HeaderCell>
-        <Table.HeaderCell className={styles['table-header']}>Details</Table.HeaderCell>
-        <Table.HeaderCell className={styles['table-header']}>Time</Table.HeaderCell>
+        <Table.HeaderCell verticalAlign="bottom">{selectAllIcon}</Table.HeaderCell>
+        <Table.HeaderCell verticalAlign="bottom" className={styles['table-header']}>Details</Table.HeaderCell>
+        <Table.HeaderCell verticalAlign="bottom" className={styles['table-header']}>Time</Table.HeaderCell>
         <Table.HeaderCell />
       </Table.Row>
     );

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -11,6 +11,7 @@ import {
   Message,
   Loader,
 } from 'semantic-ui-react';
+import classNames from 'classnames';
 import styles from './FileLoader.scss';
 import FileRow from './FileRow';
 import DismissibleMessage from './common/DismissibleMessage';
@@ -43,6 +44,7 @@ export default class FileLoader extends Component {
     super(props);
     this.state = {
       selections: [],
+      areAllSelected: false,
     };
   }
 
@@ -92,6 +94,7 @@ export default class FileLoader extends Component {
 
     this.setState({
       selections: newSelections,
+      areAllSelected: newSelections.length === this.props.store.files.length,
     });
   }
 
@@ -127,6 +130,7 @@ export default class FileLoader extends Component {
   queueClear = () => {
     this.setState({
       selections: [],
+      areAllSelected: false,
     });
   }
 
@@ -138,7 +142,10 @@ export default class FileLoader extends Component {
   }
 
   selectAll = () => {
-    this.setState({ selections: this.props.store.files });
+    this.setState((prevState) => ({
+      selections: prevState.areAllSelected ? [] : this.props.store.files,
+      areAllSelected: !prevState.areAllSelected,
+    }));
   }
 
   renderGlobalError() {
@@ -279,10 +286,21 @@ export default class FileLoader extends Component {
       return this.renderEmptyLoader();
     }
 
+    const cellStyles = classNames({
+      [styles['select-cell']]: true,
+      [styles['selected']]: this.state.areAllSelected,
+    });
+
+    const selectAllIcon = this.state.areAllSelected ? (
+      <Icon size="big" name="check square outline" onClick={this.selectAll} className={cellStyles} />
+    ) : (
+      <Icon size="big" name="square outline" onClick={this.selectAll} className={cellStyles} />
+    )
+
     // Generate header row
     const headerRow = (
       <Table.Row>
-        <Table.HeaderCell />
+        <Table.HeaderCell>{selectAllIcon}</Table.HeaderCell>
         <Table.HeaderCell>Details</Table.HeaderCell>
         <Table.HeaderCell>Time</Table.HeaderCell>
         <Table.HeaderCell />
@@ -321,14 +339,10 @@ export default class FileLoader extends Component {
   }
 
   renderQueueButtons() {
-    return this.state.selections.length === 0 ? (
-      <div className={styles['queue-buttons']}>
-        <Button onClick={this.selectAll}>
-          <Icon name="plus" />
-          Select all
-        </Button>
-      </div>
-    ) : (
+    if (this.state.selections.length === 0) {
+      return;
+    }
+    return (
       <div className={styles['queue-buttons']}>
         <Button onClick={this.queueFiles}>
           <Icon name="play circle" />

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -137,9 +137,8 @@ export default class FileLoader extends Component {
     });
   }
 
-  queueAllFiles = () => {
-    const filteredFiles = this.processFiles(this.state.files)
-    this.props.queueFiles(_.reverse(filteredFiles));
+  selectAll = () => {
+    this.setState({ selections: this.props.store.files });
   }
 
   renderGlobalError() {
@@ -324,9 +323,9 @@ export default class FileLoader extends Component {
   renderQueueButtons() {
     return this.state.selections.length === 0 ? (
       <div className={styles['queue-buttons']}>
-        <Button onClick={this.queueAllFiles}>
-          <Icon name="play circle" />
-          Play all
+        <Button onClick={this.selectAll}>
+          <Icon name="plus" />
+          Select all
         </Button>
       </div>
     ) : (

--- a/app/components/FileLoader.scss
+++ b/app/components/FileLoader.scss
@@ -68,3 +68,33 @@
   bottom: 20px;
   left: 20px;
 }
+
+.select-cell {
+  margin-left: 10px !important;
+
+  i {
+    color: #94969A;
+  }
+
+  i:hover {
+    color: #FFFFFF;
+    cursor: pointer;
+  }
+
+  &.selected {
+    i {
+      color: rgba(255, 255, 255, 0.75);
+    }
+
+    i:hover {
+      color: #FFFFFF;
+      cursor: pointer;
+    }
+  }
+
+  .pos-text {
+    margin-left: 4px;
+    font-weight: bold;
+    color: rgba(255, 255, 255, 0.5);
+  }
+}

--- a/app/components/FileLoader.scss
+++ b/app/components/FileLoader.scss
@@ -98,3 +98,7 @@
     color: rgba(255, 255, 255, 0.5);
   }
 }
+
+.table-header {
+  font-size: 1.2em;
+}

--- a/app/components/FileRow.js
+++ b/app/components/FileRow.js
@@ -36,7 +36,7 @@ export default class FileRow extends Component {
   };
 
   onSelect = () => {
-    this.props.onSelect(this.props.file);
+    this.props.onSelect(this.props.file, this.props.fileIndex);
   };
 
   viewStats = (e) => {

--- a/app/utils/keymap.js
+++ b/app/utils/keymap.js
@@ -1,0 +1,11 @@
+const keyMap = {};
+
+document.addEventListener('keydown', (event) => {
+  keyMap[event.key] = true;
+});
+
+document.addEventListener('keyup', (event) => {
+  keyMap[event.key] = false;
+});
+
+export default keyMap;


### PR DESCRIPTION
Originally intended to be an auto "play all" feature, but with the queue feature already being merged in I've piggybacked off of it and just made a "select all" for it.

[Trello](https://trello.com/c/Fxes0Izs/118-play-all-button-to-play-all-files-in-a-folder-in-a-row)

Pre-select
![image](https://user-images.githubusercontent.com/9536605/76656272-40098e80-653d-11ea-8174-d7dab4e2f144.png)

Post-select
![image](https://user-images.githubusercontent.com/9536605/76656297-4ac42380-653d-11ea-8c9e-b7989f4291a5.png)