### PR TITLE
Stats page nav

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,6 +30,7 @@
     "no-mixed-operators": "off",
     "no-use-before-define": "off",
     "no-multi-assign": "off",
+    "no-plusplus": "off",
     "object-shorthand": ["error", "never"],
     "one-var": "off",
     "one-var-declaration-per-line": "off",

--- a/app/components/FileRow.js
+++ b/app/components/FileRow.js
@@ -16,8 +16,9 @@ const path = require('path');
 export default class FileRow extends Component {
   static propTypes = {
     file: PropTypes.object.isRequired,
+    fileIndex: PropTypes.number.isRequired,
     playFile: PropTypes.func.isRequired,
-    gameProfileLoad: PropTypes.func.isRequired,
+    setStatsGamePage: PropTypes.func.isRequired,
     onSelect: PropTypes.func.isRequired,
     selectedOrdinal: PropTypes.number.isRequired,
   };
@@ -40,10 +41,7 @@ export default class FileRow extends Component {
 
   viewStats = (e) => {
     e.stopPropagation();
-    const file = this.props.file || {};
-    const fileGame = file.game;
-
-    this.props.gameProfileLoad(fileGame);
+    this.props.setStatsGamePage(this.props.fileIndex);
   };
 
   generateSelectCell() {
@@ -216,7 +214,7 @@ export default class FileRow extends Component {
             />
           </Link>
         </SpacedGroup>
-        
+
       </Table.Cell>
     );
   }

--- a/app/components/stats/GameProfile.js
+++ b/app/components/stats/GameProfile.js
@@ -224,6 +224,24 @@ export default class GameProfile extends Component {
     return (
       <Segment className={gameDetailsClasses} basic={true}>
         {metadataElements}
+        <div className={styles['nav-button']}>
+          <Button
+            content="Prev"
+            circular={true}
+            color="grey"
+            basic={true}
+            inverted={true}
+            size="tiny"
+          />
+          <Button
+            content="Next"
+            circular={true}
+            color="grey"
+            basic={true}
+            inverted={true}
+            size="tiny"
+          />
+        </div>
       </Segment>
     );
   }

--- a/app/components/stats/GameProfile.js
+++ b/app/components/stats/GameProfile.js
@@ -33,6 +33,7 @@ export default class GameProfile extends Component {
 
     // fileLoaderAction
     playFile: PropTypes.func.isRequired,
+    setStatsGamePage: PropTypes.func.isRequired,
 
     // error actions
     dismissError: PropTypes.func.isRequired,
@@ -41,6 +42,7 @@ export default class GameProfile extends Component {
     store: PropTypes.object.isRequired,
     errors: PropTypes.object.isRequired,
     topNotifOffset: PropTypes.number.isRequired,
+    statsGameIndex: PropTypes.number.isRequired,
   };
 
   refStats = null;
@@ -57,6 +59,14 @@ export default class GameProfile extends Component {
       fullPath: filePath,
     });
   };
+
+  nextGame = () => {
+    this.props.setStatsGamePage(this.props.statsGameIndex + 1);
+  }
+
+  prevGame = () => {
+    this.props.setStatsGamePage(this.props.statsGameIndex - 1);
+  }
 
   renderContent() {
     const isLoading = _.get(this.props.store, 'isLoading') || false;
@@ -165,7 +175,7 @@ export default class GameProfile extends Component {
   renderGameDetails() {
     const gameSettings = _.get(this.props.store, ['game', 'settings']) || {};
     const stageName = _.isNil(gameSettings.stageId) ? "Unknown" : stageUtils.getStageName(gameSettings.stageId);
-    
+
     const duration =
       _.get(this.props.store, ['game', 'stats', 'lastFrame']) || 0;
     const durationDisplay = timeUtils.convertFrameCountToDurationString(
@@ -232,6 +242,7 @@ export default class GameProfile extends Component {
             basic={true}
             inverted={true}
             size="tiny"
+            onClick={this.prevGame}
           />
           <Button
             content="Next"
@@ -240,6 +251,7 @@ export default class GameProfile extends Component {
             basic={true}
             inverted={true}
             size="tiny"
+            onClick={this.nextGame}
           />
         </div>
       </Segment>

--- a/app/components/stats/GameProfile.scss
+++ b/app/components/stats/GameProfile.scss
@@ -47,7 +47,7 @@ $header-height: 97px;
 
   .game-details {
     margin: 0 !important;
-    padding: 0 0 14px 0 !important;
+    padding: 14px 0 14px 0 !important;
 
     display: flex;
     justify-content: start;
@@ -79,6 +79,8 @@ $header-height: 97px;
     position: absolute;
     right: 0px;
     padding-right: 0px !important;
+    transform: translateY(-50%);
+    top: 50%;
   }
 
   .character-image {

--- a/app/components/stats/GameProfile.scss
+++ b/app/components/stats/GameProfile.scss
@@ -75,6 +75,12 @@ $header-height: 97px;
     }
   }
 
+  .nav-button {
+    position: absolute;
+    right: 0px;
+    padding-right: 0px !important;
+  }
+
   .character-image {
     height: 36px !important;
     width: 36px !important;

--- a/app/components/stats/GameProfile.scss
+++ b/app/components/stats/GameProfile.scss
@@ -46,8 +46,8 @@ $header-height: 97px;
   }
 
   .game-details {
-    margin: 0 !important;
-    padding: 14px 0 14px 0 !important;
+    margin: 0 0 14px 0 !important;
+    padding: 14px 0 0 0 !important;
 
     display: flex;
     justify-content: start;
@@ -79,8 +79,7 @@ $header-height: 97px;
     position: absolute;
     right: 0px;
     padding-right: 0px !important;
-    transform: translateY(-50%);
-    top: 50%;
+    bottom: 0px;
   }
 
   .character-image {

--- a/app/containers/GameProfilePage.js
+++ b/app/containers/GameProfilePage.js
@@ -2,12 +2,13 @@ import _ from "lodash";
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import GameProfile from '../components/stats/GameProfile';
-import { playFile } from "../actions/fileLoader";
+import { playFile, setStatsGamePage } from "../actions/fileLoader";
 import { dismissError } from "../actions/error";
 
 function mapStateToProps(state) {
   return {
     store: state.game,
+    statsGameIndex: state.fileLoader.statsGameIndex,
     errors: state.errors,
     topNotifOffset: _.get(state.notifs, ['activeNotif', 'heightPx']) || 0,
   };
@@ -17,6 +18,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({
     playFile: playFile,
     dismissError: dismissError,
+    setStatsGamePage: setStatsGamePage,
   }, dispatch);
 }
 

--- a/app/reducers/fileLoader.js
+++ b/app/reducers/fileLoader.js
@@ -1,5 +1,5 @@
 import {
-  LOAD_ROOT_FOLDER, CHANGE_FOLDER_SELECTION, LOAD_FILES_IN_FOLDER, STORE_SCROLL_POSITION,
+  LOAD_ROOT_FOLDER, CHANGE_FOLDER_SELECTION, LOAD_FILES_IN_FOLDER, STORE_SCROLL_POSITION, SET_STATS_GAME_PAGE,
 } from '../actions/fileLoader';
 import DolphinManager from '../domain/DolphinManager';
 
@@ -16,6 +16,8 @@ const defaultState = {
   files: [],
   folderFound: false,
   playingFile: null,
+  numFilteredFiles: 0,
+  statsGameIndex: 0,
   scrollPosition: {
     x: 0,
     y: 0,
@@ -32,6 +34,8 @@ export default function fileLoader(state = defaultState, action) {
     return loadFilesInFolder(state, action);
   case STORE_SCROLL_POSITION:
     return storeScrollPosition(state, action);
+  case SET_STATS_GAME_PAGE:
+    return setStatsGamePage(state, action);
   default:
     return state;
   }
@@ -107,6 +111,7 @@ function loadFilesInFolder(state, action) {
     isLoading: false,
     files: action.payload.files,
     folders: folders,
+    numFilteredFiles: action.payload.numFilteredFiles,
   };
 }
 
@@ -114,5 +119,12 @@ function storeScrollPosition(state, action) {
   return {
     ...state,
     scrollPosition: action.payload.position,
+  };
+}
+
+function setStatsGamePage(state, action) {
+  return {
+    ...state,
+    statsGameIndex: action.payload.statsGameIndex,
   };
 }


### PR DESCRIPTION
Added buttons for navigating to previous and next matches in replay folder without leaving the stats page. Lifted filtering short/error files from component to redux store level due to have access to file list in GameProfile component.

[Trello](https://trello.com/c/UiHlb8iP/147-navigate-between-games-on-stats-page)

![image](https://user-images.githubusercontent.com/9536605/76655926-7a266080-653c-11ea-8c67-4449ef1b4b00.png)