### PR TITLE
Fix bad UBJSON due to null isRealTimeMode

### DIFF
--- a/app/components/Console.js
+++ b/app/components/Console.js
@@ -554,7 +554,8 @@ export default class Console extends Component {
 
   renderAvailable = (info) => {
     const defaultSettings = {
-      'ipAddress': info.ip,
+      ipAddress: info.ip,
+      isRealTimeMode: true,
     };
 
     return (

--- a/app/domain/ConsoleCommunication.js
+++ b/app/domain/ConsoleCommunication.js
@@ -71,7 +71,7 @@ export default class ConsoleCommunication {
     return toReturn;
   }
 
-  genHandshakeOut(cursor, clientToken, isRealtime) {
+  genHandshakeOut(cursor, clientToken, isRealtime=false) {
     const clientTokenBuf = Buffer.from([0, 0, 0, 0]);
     clientTokenBuf.writeUInt32BE(clientToken, 0);
 


### PR DESCRIPTION
Fixes available connections not using a default `isRealTimeMode`.

Set isRealtime to false in `genHandshakeOut`

fixes #55 