### PR TITLE
Performance: Lazy Load Game Rows in Replay Browser

### DIFF
--- a/app/actions/fileLoader.js
+++ b/app/actions/fileLoader.js
@@ -14,6 +14,7 @@ export const CHANGE_FOLDER_SELECTION = 'CHANGE_FOLDER_SELECTION';
 export const LOAD_FILES_IN_FOLDER = 'LOAD_FILES_IN_FOLDER';
 export const SET_STATS_GAME_PAGE = 'SET_STATS_GAME_PAGE';
 export const STORE_SCROLL_POSITION = 'STORE_SCROLL_POSITION';
+export const STORE_FILE_LOAD_STATE = 'STORE_FILE_LOAD_STATE';
 
 export function loadRootFolder() {
   return async (dispatch, getState) => {
@@ -115,6 +116,15 @@ export function storeScrollPosition(position) {
     type: STORE_SCROLL_POSITION,
     payload: {
       position: position,
+    },
+  };
+}
+
+export function storeFileLoadState(fileLoadState) {
+  return {
+    type: STORE_FILE_LOAD_STATE,
+    payload: {
+      fileLoadState: fileLoadState,
     },
   };
 }

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -20,6 +20,8 @@ import FolderBrowser from './common/FolderBrowser';
 import PageWrapper from './PageWrapper';
 import Scroller from './common/Scroller';
 
+const GAME_BATCH_SIZE = 10;
+
 export default class FileLoader extends Component {
   static propTypes = {
     // fileLoader actions
@@ -319,17 +321,15 @@ export default class FileLoader extends Component {
     );
 
     const bufferMoreFiles = () => {
-      const fileBufferSize = 10;
-
       const start = filesOffset;
-      const end = Math.min(start + fileBufferSize, allFiles.length);
+      const end = Math.min(start + GAME_BATCH_SIZE, allFiles.length);
 
       if (start < allFiles.length)
       {
         const nextFilesToRender = allFiles.slice(start, end);
         this.setState({
           filesToRender: filesToRender.concat(nextFilesToRender),
-          filesOffset: end+1,
+          filesOffset: end,
         });
       }
     }

--- a/app/reducers/fileLoader.js
+++ b/app/reducers/fileLoader.js
@@ -1,5 +1,5 @@
 import {
-  LOAD_ROOT_FOLDER, CHANGE_FOLDER_SELECTION, LOAD_FILES_IN_FOLDER, STORE_SCROLL_POSITION, SET_STATS_GAME_PAGE,
+  LOAD_ROOT_FOLDER, CHANGE_FOLDER_SELECTION, LOAD_FILES_IN_FOLDER, STORE_SCROLL_POSITION, SET_STATS_GAME_PAGE, STORE_FILE_LOAD_STATE,
 } from '../actions/fileLoader';
 import DolphinManager from '../domain/DolphinManager';
 
@@ -34,6 +34,8 @@ export default function fileLoader(state = defaultState, action) {
     return loadFilesInFolder(state, action);
   case STORE_SCROLL_POSITION:
     return storeScrollPosition(state, action);
+  case STORE_FILE_LOAD_STATE:
+    return storeFileLoadState(state, action);
   case SET_STATS_GAME_PAGE:
     return setStatsGamePage(state, action);
   default:
@@ -119,6 +121,13 @@ function storeScrollPosition(state, action) {
   return {
     ...state,
     scrollPosition: action.payload.position,
+  };
+}
+
+function storeFileLoadState(state, action) {
+  return {
+    ...state,
+    fileLoadState: action.payload.fileLoadState,
   };
 }
 

--- a/app/reducers/fileLoader.js
+++ b/app/reducers/fileLoader.js
@@ -114,6 +114,7 @@ function loadFilesInFolder(state, action) {
     files: action.payload.files,
     folders: folders,
     numFilteredFiles: action.payload.numFilteredFiles,
+    fileLoadState: {},
   };
 }
 


### PR DESCRIPTION
Fixes #53

The approach taken here is similar to an infinite scroll - we'll lazy-load game rows in chunks of a pre-configured size, whenever we've reached the end of the table that we've already loaded. We use the `Visibility` element to determine whether the element at the end of the table is visible, and then use the callback that is triggered to render another chunk of games.