### PR TITLE
Remove checking for PUSH action on file loader menu

### DIFF
--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -52,12 +52,7 @@ export default class FileLoader extends Component {
 
     this.refTableScroll.scrollTo(xPos, yPos);
 
-    if (this.props.history.action === "PUSH") {
-      // I don't really like this but when returning back to the file loader, the action is "POP"
-      // instead of "PUSH", and we don't want to trigger the loader and ruin our ability to restore
-      // scroll position when returning to fileLoader from a game
-      this.props.loadRootFolder();
-    }
+    this.props.loadRootFolder();
   }
 
   componentWillUnmount() {

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -52,7 +52,12 @@ export default class FileLoader extends Component {
 
     this.refTableScroll.scrollTo(xPos, yPos);
 
-    this.props.loadRootFolder();
+    if (this.props.history.action === "PUSH") {
+      // I don't really like this but when returning back to the file loader, the action is "POP"
+      // instead of "PUSH", and we don't want to trigger the loader and ruin our ability to restore
+      // scroll position when returning to fileLoader from a game
+      this.props.loadRootFolder();
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
From testing I found that this conditional is only preventing the user's files from loading on first use (selecting 'Select Folder' from the replay browser without an slp file path set). If the user is redirected to the settings menu without an slp file path set and then hits 'Back' after setting a file path, the files will not load because of this conditional. Functionality for storing scroll position after the user views match statistics or goes back to the main menu remain the same.