### PR TITLE
Display netplay codes on the app.

### DIFF
--- a/app/components/common/PlayerChiclet.js
+++ b/app/components/common/PlayerChiclet.js
@@ -24,9 +24,9 @@ export default class PlayerChiclet extends Component {
     const game = this.props.game;
     const index = this.props.playerIndex;
 
-    const name = playerUtils.getPlayerName(game, index);
+    const displayName = playerUtils.getPlayerCode(game, index) || playerUtils.getPlayerName(game, index);
 
-    return <div className={styles['name-display']}>{name}</div>;
+    return <div className={styles['name-display']}>{displayName}</div>;
   }
 
   renderCharacterBadge(player) {

--- a/app/components/stats/GameProfile.js
+++ b/app/components/stats/GameProfile.js
@@ -11,6 +11,7 @@ import {
   Modal,
   Message,
   Loader,
+  Label,
 } from 'semantic-ui-react';
 import { stages as stageUtils } from 'slp-parser-js';
 
@@ -154,11 +155,26 @@ export default class GameProfile extends Component {
       'horizontal-spaced-group-left-sm': !isFirstPlayer,
     });
 
+    const labelClasses = classNames({
+      [styles['player-code-display']]: true,
+      [styles['second']]: !isFirstPlayer,
+      'horizontal-spaced-group-right-sm': isFirstPlayer,
+      'horizontal-spaced-group-left-sm': !isFirstPlayer,
+    })
+
     const game = this.props.store.game;
     const playerNamesByIndex = playerUtils.getPlayerNamesByIndex(game);
+    const playerCodesByIndex = playerUtils.getPlayerCodesByIndex(game);
+
+    const playerCode = playerCodesByIndex[player.playerIndex];
 
     return (
       <Segment className={segmentClasses} textAlign="center" basic={true}>
+        {playerCode ? (
+          <Label size="mini" className={labelClasses}>
+            {playerCode}
+          </Label>
+        ) : null }
         <Header inverted={true} textAlign="center" as="h2">
           {playerNamesByIndex[player.playerIndex]}
         </Header>

--- a/app/components/stats/GameProfile.js
+++ b/app/components/stats/GameProfile.js
@@ -171,7 +171,7 @@ export default class GameProfile extends Component {
     return (
       <Segment className={segmentClasses} textAlign="center" basic={true}>
         {playerCode ? (
-          <Label size="mini" className={labelClasses}>
+          <Label size="large" className={labelClasses}>
             {playerCode}
           </Label>
         ) : null }

--- a/app/components/stats/GameProfile.scss
+++ b/app/components/stats/GameProfile.scss
@@ -26,6 +26,16 @@ $header-height: 97px;
 
       justify-self: end;
 
+      .player-code-display {
+        margin-left: 0;
+        background-color: $background-light !important;
+        color: rgba(255, 255, 255, 0.8);
+
+        &.second {
+          margin-left: 6px;
+        }
+      }
+
       &.second {
         justify-content: flex-start;
         align-items: center;

--- a/app/utils/players.js
+++ b/app/utils/players.js
@@ -1,5 +1,26 @@
 import _ from 'lodash';
 
+export function getPlayerCodesByIndex(game) {
+  if (!game) {
+    return null;
+  }
+
+  const settings = game.getSettings() || {};
+  const metadata = game.getMetadata() || {};
+
+  const players = settings.players || [];
+
+  return _.chain(players).keyBy('playerIndex').mapValues(player => {
+    // Netplay code
+    const names = _.get(metadata, ['players', player.playerIndex, 'names']) || {};
+    const netplayCode = names.code;
+
+    // If there is none, there is none.
+    // No fallback since we're always displaying the player name next to it.
+    return netplayCode || null;
+  }).value();
+}
+
 export function getPlayerNamesByIndex(game) {
   if (!game) {
     return {};
@@ -28,4 +49,9 @@ export function getPlayerNamesByIndex(game) {
 export function getPlayerName(game, playerIndex) {
   const playerNames = getPlayerNamesByIndex(game);
   return playerNames[playerIndex];
+}
+
+export function getPlayerCode(game, playerIndex) {
+  const playerCodes = getPlayerCodesByIndex(game);
+  return playerCodes[playerIndex];
 }


### PR DESCRIPTION
Currently, this will display the netplay name and code on the game profile page. On the file list, it displays the code and falls back to the old player name logic if there is no code.

Screenshots (second image using Player 1 and 2 since this is before the update to pass nicknames for players on Dolphin):
![image](https://user-images.githubusercontent.com/7984721/85938266-b0180680-b8d9-11ea-9dc6-3748c31a723b.png)

![image](https://user-images.githubusercontent.com/7984721/85937818-033b8a80-b8d5-11ea-8239-5f39c9fd126e.png)