### PR TITLE
Spectator changes + fix performance bug

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,7 @@
     "no-console": "off",
     "no-continue": "off",
     "no-mixed-operators": "off",
+    "no-underscore-dangle": "off",
     "no-use-before-define": "off",
     "no-multi-assign": "off",
     "no-plusplus": "off",

--- a/app/domain/ConnectionScanner.js
+++ b/app/domain/ConnectionScanner.js
@@ -10,28 +10,6 @@ export default class ConnectionScanner {
     this.isScanning = false;
     this.availableConnectionsByIp = {};
     this.server = null;
-
-    // TODO: Remove
-    // this.availableConnectionsByIp = {
-    //   '192.168.1.500': {
-    //     'ip': '192.168.1.500',
-    //     'mac': '1241:4214',
-    //     'name': "Station Foo",
-    //     'firstFound': moment(),
-    //   },
-    //   '192.168.1.501': {
-    //     'ip': '192.168.1.501',
-    //     'mac': '1241:4214',
-    //     'name': "Station Bar",
-    //     'firstFound': moment(),
-    //   },
-    //   '192.168.1.42': {
-    //     'ip': '192.168.1.42',
-    //     'mac': '1241:4214',
-    //     'name': "Station Zoob",
-    //     'firstFound': moment(),
-    //   },
-    // };
   }
 
   forceConsoleUiUpdate() {
@@ -48,10 +26,9 @@ export default class ConnectionScanner {
 
   handleMessageReceive = (msg, rinfo) => {
     if (msg.slice(0, 10).toString() !== "SLIP_READY") {
-      // This is not a Slippi broadcast message, do nothing
       return;
     }
-    
+
     /* The structure of broadcast messages from the Wii should be:
      *  unsigned char cmd[10]; // 0 - 10
      *  u8 mac_addr[6]; // 10 - 16
@@ -79,7 +56,7 @@ export default class ConnectionScanner {
     const previousTimeoutHandler = _.get(previous, 'timeout');
     const previousFirstFound = _.get(previous, 'firstFound');
 
-    // If we have received a new message from this IP, clear the previous 
+    // If we have received a new message from this IP, clear the previous
     // timeout hanlder so that this IP doesn't get removed
     if (previousTimeoutHandler) {
       clearTimeout(previousTimeoutHandler);
@@ -98,7 +75,7 @@ export default class ConnectionScanner {
       'timeout': timeoutHandler,
       'firstFound': previousFirstFound || moment(),
     };
-    
+
     // Force UI update to show new connection
     this.forceConsoleUiUpdate();
   }

--- a/app/domain/ConsoleConnection.js
+++ b/app/domain/ConsoleConnection.js
@@ -147,9 +147,8 @@ export default class ConsoleConnection {
     // }
 
     this.connectToSpectate();
-    // TODO Turn these back on. But it was causing issues
-    // this.connectOnPort(Ports.WII_DEFAULT);
-    // this.connectOnPort(Ports.WII_LEGACY);
+    this.connectOnPort(Ports.WII_DEFAULT);
+    this.connectOnPort(Ports.WII_LEGACY);
   }
 
   connectToSpectate() {

--- a/app/domain/SlpFile.js
+++ b/app/domain/SlpFile.js
@@ -1,0 +1,30 @@
+export default class SlpFile {
+  constructor({ path, writeStream, startTime }) {
+    this.payloadSizes = {}
+    this.previousBuffer = Buffer.from([])
+    this._fullBuffer = Buffer.from([])
+    this._buffersToConcat = []
+    this.lastIndex = 0
+    this.path = path || null
+    this.writeStream = writeStream || null
+    this.bytesWritten = 0
+    this.metadata = {
+      startTime: startTime || null,
+      lastFrame: -124,
+      players: {},
+    }
+  }
+
+  get fullBuffer() {
+    if (this._buffersToConcat.length > 0) {
+      this._fullBuffer = Buffer.concat([this._fullBuffer, ...this._buffersToConcat])
+    }
+    this._buffersToConcat = []
+    return this._fullBuffer
+  }
+
+  addBuffer(buffer) {
+    this.buffersToConcat.push(buffer)
+  }
+}
+

--- a/app/domain/SlpFile.js
+++ b/app/domain/SlpFile.js
@@ -24,7 +24,7 @@ export default class SlpFile {
   }
 
   addBuffer(buffer) {
-    this.buffersToConcat.push(buffer)
+    this._buffersToConcat.push(buffer)
   }
 }
 

--- a/app/store/configureStore.dev.js
+++ b/app/store/configureStore.dev.js
@@ -39,14 +39,12 @@ const configureStore = initialState => {
     ...routerActions,
   };
   // If Redux DevTools Extension is installed use it, otherwise use Redux compose
-  /* eslint-disable no-underscore-dangle */
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
     ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
       // Options: http://extension.remotedev.io/docs/API/Arguments.html
       actionCreators: actionCreators,
     })
     : compose;
-  /* eslint-enable no-underscore-dangle */
 
   // Apply Middleware & Compose Enhancers
   enhancers.push(applyMiddleware(...middleware));

--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "electron": "^4.1.4",
     "electron-builder": "^20.34.0",
     "electron-devtools-installer": "^2.2.4",
+    "enet": "^0.2.9",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",
     "enzyme-to-json": "^3.3.4",
@@ -257,6 +258,7 @@
     "@google-cloud/storage": "^2.4.2",
     "@shelacek/ubjson": "^1.0.1",
     "async-retry": "^1.2.3",
+    "bufferutil": "^4.0.1",
     "classnames": "^2.2.6",
     "devtron": "^1.4.0",
     "electron-debug": "^2.0.0",
@@ -283,7 +285,8 @@
     "semantic-ui-react": "^0.84.0",
     "semver": "^5.6.0",
     "slp-parser-js": "^4.0.0",
-    "source-map-support": "^0.5.9"
+    "source-map-support": "^0.5.9",
+    "utf-8-validate": "^5.0.2"
   },
   "devEngines": {
     "node": ">=7.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2949,6 +2949,13 @@ buffer@^5.1.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
+bufferutil@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.1.tgz#3a177e8e5819a1243fe16b63a199951a7ad8d4a7"
+  integrity sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==
+  dependencies:
+    node-gyp-build "~3.7.0"
+
 builder-util-runtime@8.1.0, builder-util-runtime@^8.1.0, builder-util-runtime@~8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.1.0.tgz#dd7fca995d48ceee7580b4851ca057566c94601e"
@@ -4774,6 +4781,11 @@ endpoint-utils@^1.0.2:
   dependencies:
     ip "^1.1.3"
     pinkie-promise "^1.0.0"
+
+enet@^0.2.9:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/enet/-/enet-0.2.9.tgz#d7fd68a0bf8bb3891408ea465e26ed6955822a1a"
+  integrity sha1-1/1ooL+Ls4kUCOpGXibtaVWCKho=
 
 enhanced-resolve@^4.1.0:
   version "4.1.0"
@@ -8844,6 +8856,11 @@ node-forge@^0.7.5:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
   integrity sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==
+
+node-gyp-build@~3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-3.7.0.tgz#daa77a4f547b9aed3e2aac779eaf151afd60ec8d"
+  integrity sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w==
 
 node-gyp@^3.8.0:
   version "3.8.0"
@@ -13037,6 +13054,13 @@ useragent@^2.1.7:
   dependencies:
     lru-cache "4.1.x"
     tmp "0.0.x"
+
+utf-8-validate@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.2.tgz#63cfbccd85dc1f2b66cf7a1d0eebc08ed056bfb3"
+  integrity sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==
+  dependencies:
+    node-gyp-build "~3.7.0"
 
 utf8-byte-length@^1.0.1:
   version "1.0.4"


### PR DESCRIPTION
Forked from @altf4's `spectator` branch [here](https://github.com/altf4/slippi-desktop-app/tree/spectator) which should be used with [this corresponding Ishiiruka PR](https://github.com/project-slippi/Ishiiruka/pull/98).

Includes all of his changes, along with:

- Refactor `SlpFileWriter#currentFile` to instance of new `SlpFile` class. (Open to better names for this new class.)
- Only merge `previousBuffer` if it exists
- Properly check if clients array has items with `.length`
- Only concat buffers when `fullBuffer` is accessed via getter
- Linting changes / fixes

This PR defers merging of buffer data to `fullBuffer` until it is accessed, which resolves performance issues *as long as no clients are connected via relay mode*. This problem still exists in relay mode, but will be addressed in a subsequent PR.