### PR TITLE
Numerically sort subdirectories

### DIFF
--- a/app/components/common/FolderBrowser.js
+++ b/app/components/common/FolderBrowser.js
@@ -28,8 +28,11 @@ export default class FolderBrowser extends Component {
     // Generate directory listing if we have subdirectories
     let subDirectoryList = null;
     if (_.some(subFolderItems)) {
+      // Sort the subdirectories numerically instead of lexicographically
+      var numericallySortedSubFolderItems = Array.from(subFolderItems).sort((a, b) => a[1].key.localeCompare(b[1].key, undefined, {numeric: true, sensitivity: 'base'}));
+
       subDirectoryList = (
-        <List.List className="no-padding">{subFolderItems}</List.List>
+        <List.List className="no-padding">{numericallySortedSubFolderItems}</List.List>
       );
     }
 

--- a/app/components/common/FolderBrowser.js
+++ b/app/components/common/FolderBrowser.js
@@ -29,7 +29,7 @@ export default class FolderBrowser extends Component {
     let subDirectoryList = null;
     if (_.some(subFolderItems)) {
       // Sort the subdirectories numerically instead of lexicographically
-      var numericallySortedSubFolderItems = Array.from(subFolderItems).sort((a, b) => a[1].key.localeCompare(b[1].key, undefined, {numeric: true, sensitivity: 'base'}));
+      const numericallySortedSubFolderItems = subFolderItems.sort((a, b) => a[1].key.localeCompare(b[1].key, undefined, {numeric: true, sensitivity: 'base'}));
 
       subDirectoryList = (
         <List.List className="no-padding">{numericallySortedSubFolderItems}</List.List>


### PR DESCRIPTION
This is a minor change that adjusts the ordering of subdirectories in the Replay Browser.

Currently, the subdirectories are sorted in the default string ordering - lexicographic. However, most users will naturally expect numeric ordering, which is the default directory ordering for Windows. I am unsure of the default ordering for Unix systems.

Before this change, directories would be ordered "10", "100, "25"
After the change, the order becomes "10", "25", "100"

Before:
![image](https://user-images.githubusercontent.com/8659630/86988024-529b7980-c165-11ea-9e19-f03ddd7afa6c.png)

After:
![image](https://user-images.githubusercontent.com/8659630/86988079-6d6dee00-c165-11ea-9e34-ac48e2de6f65.png)
