### PR TITLE
use file creation date in "Details" of Replay Browser if the date is not available in the metadata

### DIFF
--- a/app/components/FileRow.js
+++ b/app/components/FileRow.js
@@ -12,6 +12,7 @@ import PlayerChiclet from './common/PlayerChiclet';
 import * as timeUtils from '../utils/time';
 
 const path = require('path');
+const fs = require('fs');
 
 export default class FileRow extends Component {
   static propTypes = {
@@ -215,7 +216,7 @@ export default class FileRow extends Component {
     const file = this.props.file || {};
 
     const metadata = file.game.getMetadata() || {};
-    const startAt = metadata.startAt;
+    const startAt = metadata.startAt || fs.statSync(file.fullPath).ctime;
     const startAtDisplay = timeUtils.convertToDateAndTime(startAt) || 'Unknown';
 
     return <Table.Cell singleLine={true}>{startAtDisplay}</Table.Cell>;


### PR DESCRIPTION
Fixes #73 

This uses the `fs` module to get the creation date of the file if the metadata could not provide a start time. 
