### PR TITLE
properly store and restore scroll position when viewing recording stats

### DIFF
--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -97,11 +97,6 @@ export default class FileLoader extends Component {
       y: this.refTableScroll.scrollTop,
     });
 
-    // this.props.storeFileLoadState({
-    //   filesToRender: this.state.filesToRender,
-    //   filesOffset: this.state.filesOffset,
-    // });
-
     this.props.dismissError('fileLoader-global');
   }
 

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -57,6 +57,18 @@ export default class FileLoader extends Component {
       // main menu is "PUSH". When coming from the main menu, we want to reload the files such that
       // any new files show up correctly
       this.props.loadRootFolder();
+
+      // Arriving at the file browser from the top level menu should reset the scroll position because
+      // the files may be different than when we last looked.
+      this.props.storeScrollPosition({
+        x: 0,
+        y: 0,
+      });
+    } else if (this.props.history.action === "POP") {
+      const xPos = _.get(this.props.store, ['scrollPosition', 'x']) || 0;
+      const yPos = _.get(this.props.store, ['scrollPosition', 'y']) || 0;
+
+      this.refTableScroll.scrollTo(xPos, yPos);
     }
   }
 
@@ -85,10 +97,10 @@ export default class FileLoader extends Component {
       y: this.refTableScroll.scrollTop,
     });
 
-    this.props.storeFileLoadState({
-      filesToRender: this.state.filesToRender,
-      filesOffset: this.state.filesOffset,
-    });
+    // this.props.storeFileLoadState({
+    //   filesToRender: this.state.filesToRender,
+    //   filesOffset: this.state.filesOffset,
+    // });
 
     this.props.dismissError('fileLoader-global');
   }


### PR DESCRIPTION
Fixes https://github.com/project-slippi/slippi-desktop-app/issues/72

Experience changes:
- Scrolling down in the file browser, pressing back, and re-accessing the file browser will no longer scroll a random distance down.
- The position is now properly stored and restored when clicking on a recording's stats and returning to the file loader.