### PR TITLE
Allow showing of games less than 30 seconds

### DIFF
--- a/app/actions/fileLoader.js
+++ b/app/actions/fileLoader.js
@@ -215,6 +215,7 @@ async function loadFilesInFolder(folderPath) {
       const fullPath = path.join(folderPath, fileName);
       let game = null;
       let hasError = false;
+      let lastFrame = null;
 
       // Pre-load settings here
       try {
@@ -227,7 +228,10 @@ async function loadFilesInFolder(folderPath) {
         }
 
         // Preload metadata
-        game.getMetadata();
+        const metadata = game.getMetadata();
+        if (metadata && metadata.lastFrame !== undefined) {
+          lastFrame = metadata.lastFrame;
+        }
       } catch (err) {
         console.log(`Failed to parse file: ${fullPath}`);
         console.log(err);
@@ -242,6 +246,7 @@ async function loadFilesInFolder(folderPath) {
         startTime: startTime,
         game: game,
         hasError: hasError,
+        lastFrame: lastFrame,
       };
     })
   ));
@@ -284,9 +289,7 @@ function processFiles(files) {
       return false;
     }
 
-    const metadata = file.game.getMetadata() || {};
-    const totalFrames = metadata.lastFrame || 30 * 60 + 1;
-    return totalFrames > 30 * 60;
+    return true;
   });
 
   resultFiles = _.orderBy(

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -206,18 +206,18 @@ export default class FileLoader extends Component {
     }
 
     const allFiles = store.files || [];
+    // These are the number of files that were initiall removed probably because they're corrupted
+    const errorFileCount = _.get(this.props.store, 'numFilteredFiles');
+
     const files = this.unfilteredFiles();
-    const filteredFileCount = allFiles.length - files.length;
-    if (!filteredFileCount || !this.state.filterReplays) {
+    const filteredFileCount = allFiles.length - files.length + errorFileCount;
+    if (!filteredFileCount) {
       return null;
     }
 
     let contentText =
       'Replays shorter than 30 seconds are automatically filtered.';
 
-    // These are the number of files that were initiall removed probably because they're corrupted
-    const filesWithErrors = _.get(this.props.store, 'numFilteredFiles');
-    const errorFileCount = filesWithErrors.length;
     if (errorFileCount) {
       contentText = `${errorFileCount} corrupt files detected. Non-corrupt replays shorter than 30 seconds are automatically filtered.`;
     }

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -211,7 +211,7 @@ export default class FileLoader extends Component {
 
     const files = this.unfilteredFiles();
     const filteredFileCount = allFiles.length - files.length + errorFileCount;
-    if (!filteredFileCount) {
+    if (!filteredFileCount || !this.state.filterReplays) {
       return null;
     }
 

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -241,7 +241,7 @@ export default class FileLoader extends Component {
         icon="info circle"
         header={`${filteredFileCount} Files have been filtered`}
         content={<>
-          <span>{contentText}</span> <button type="button" className={styles['show-anyway']} onClick={onShowAnywayClick}>Show anyway</button>
+          <span>{contentText}</span> <button type="button" className={styles['show-anyway']} onClick={onShowAnywayClick}>Click to show all</button>
         </>}
       />
     );

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -210,17 +210,24 @@ export default class FileLoader extends Component {
     const errorFileCount = _.get(this.props.store, 'numFilteredFiles');
 
     const files = this.unfilteredFiles();
-    const filteredFileCount = allFiles.length - files.length + errorFileCount;
-    if (!filteredFileCount || !this.state.filterReplays) {
+    const durationFilterCount = allFiles.length - files.length;
+    const totalFilteredCount = durationFilterCount + errorFileCount;
+    if (totalFilteredCount === 0) {
       return null;
     }
 
     let contentText =
       `Replays shorter than ${MIN_GAME_LENGTH_SECONDS} seconds are automatically filtered.`;
 
-    if (errorFileCount) {
-      contentText = `${errorFileCount} corrupt files detected. Non-corrupt replays shorter than ${MIN_GAME_LENGTH_SECONDS} seconds are automatically filtered.`;
+    if (errorFileCount > 0) {
+      if (durationFilterCount > 0) {
+        // There are corrupted files and filtered files
+        contentText = `${errorFileCount} corrupt files detected. Non-corrupt replays shorter than ${MIN_GAME_LENGTH_SECONDS} seconds are automatically filtered.`;
+      } else {
+        contentText = `${errorFileCount} corrupt files detected.`;
+      }
     }
+    const showHideButton = durationFilterCount > 0 && this.state.filterReplays;
 
     const onShowAnywayClick = () => {
       // Clear the currently loaded files
@@ -239,9 +246,9 @@ export default class FileLoader extends Component {
       <Message
         info={true}
         icon="info circle"
-        header={`${filteredFileCount} Files have been filtered`}
+        header={`${totalFilteredCount} Files have been filtered`}
         content={<>
-          <span>{contentText}</span> <button type="button" className={styles['show-anyway']} onClick={onShowAnywayClick}>Click to show all</button>
+          <span>{contentText}</span> {showHideButton && <button type="button" className={styles['show-anyway']} onClick={onShowAnywayClick}>Click to show all</button>}
         </>}
       />
     );

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -21,7 +21,8 @@ import PageWrapper from './PageWrapper';
 import Scroller from './common/Scroller';
 
 const GAME_BATCH_SIZE = 50;
-const MIN_GAME_LENGTH_FRAMES = 30 * 60;
+const MIN_GAME_LENGTH_SECONDS = 30;
+const MIN_GAME_LENGTH_FRAMES = MIN_GAME_LENGTH_SECONDS * 60;
 
 export default class FileLoader extends Component {
   static propTypes = {
@@ -48,8 +49,7 @@ export default class FileLoader extends Component {
     super(props);
 
     this.state = {
-      // Filter 30 second replays by default
-      // Gets reset when the component is unmounted
+      // Filter the replays by default. Gets reset when the component is unmounted
       filterReplays: true,
       selections: [],
     };
@@ -216,10 +216,10 @@ export default class FileLoader extends Component {
     }
 
     let contentText =
-      'Replays shorter than 30 seconds are automatically filtered.';
+      `Replays shorter than ${MIN_GAME_LENGTH_SECONDS} seconds are automatically filtered.`;
 
     if (errorFileCount) {
-      contentText = `${errorFileCount} corrupt files detected. Non-corrupt replays shorter than 30 seconds are automatically filtered.`;
+      contentText = `${errorFileCount} corrupt files detected. Non-corrupt replays shorter than ${MIN_GAME_LENGTH_SECONDS} seconds are automatically filtered.`;
     }
 
     const onShowAnywayClick = () => {

--- a/app/components/FileLoader.js
+++ b/app/components/FileLoader.js
@@ -213,7 +213,7 @@ export default class FileLoader extends Component {
     }
 
     const allFiles = store.files || [];
-    // These are the number of files that were initiall removed probably because they're corrupted
+    // These are the number of files that were initially removed probably because they're corrupted
     const errorFileCount = _.get(this.props.store, 'numFilteredFiles');
 
     const files = this.unfilteredFiles();

--- a/app/components/FileLoader.scss
+++ b/app/components/FileLoader.scss
@@ -68,3 +68,16 @@
   bottom: 20px;
   left: 20px;
 }
+
+.show-anyway {
+  background: none;
+  border: 0;
+  color: inherit;
+  padding: 0;
+  font-weight: bold;
+
+  &:hover {
+    cursor: pointer;
+    text-decoration: underline;
+  }
+}

--- a/app/components/FileRow.js
+++ b/app/components/FileRow.js
@@ -12,6 +12,7 @@ import PlayerChiclet from './common/PlayerChiclet';
 import * as timeUtils from '../utils/time';
 
 const path = require('path');
+const shell = require('electron').shell;
 
 export default class FileRow extends Component {
   static propTypes = {
@@ -93,6 +94,10 @@ export default class FileRow extends Component {
   }
 
   generateDetailsCell() {
+    const onFileLocationClick = () => {
+      const fileLocation = path.resolve(this.props.file.fullPath);
+      shell.showItemInFolder(fileLocation);
+    }
     const metadata = [
       {
         label: 'Stage',
@@ -103,7 +108,7 @@ export default class FileRow extends Component {
       },
       {
         label: 'File',
-        content: this.getFileName(),
+        content: <button type="button" className={styles['reveal-file-location']} onClick={onFileLocationClick}>{this.getFileName()}</button>,
       },
     ];
 

--- a/app/components/FileRow.scss
+++ b/app/components/FileRow.scss
@@ -73,3 +73,14 @@
   height: 15px;
   text-align: center;
 }
+
+.reveal-file-location {
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  &:hover {
+    cursor: pointer;
+    text-decoration: underline;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.5.0",
     "@google-cloud/storage": "^2.4.2",
-    "@slippi/slippi-js": "^5.0.2",
+    "@slippi/slippi-js": "^5.0.5",
     "async-retry": "^1.2.3",
     "classnames": "^2.2.6",
     "devtron": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1056,10 +1056,10 @@
     array-from "^2.1.1"
     lodash.get "^4.4.2"
 
-"@slippi/slippi-js@^5.0.2":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@slippi/slippi-js/-/slippi-js-5.0.2.tgz#ef83372d1eaee82ba7f97ae89c549b392f261a5b"
-  integrity sha512-8r1zWjAh5PNVo386oUNu8EcIh39UrvMKsU7IVUERnhqMLhIjfFR8sVKZTgBx1gxexhzJGAVdvdEnWb6kDLbNDw==
+"@slippi/slippi-js@^5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@slippi/slippi-js/-/slippi-js-5.0.5.tgz#abb86b598451d100519a8cb7cddc048e58e2f9e2"
+  integrity sha512-iVFhJz1njibZf55KCSk8egRpuc85EnkWQtARnNLzzE6nzffMbUwZip5dHwhuH2PI8BRnPmN2M0d9Ri5QdTaZ/g==
   dependencies:
     "@shelacek/ubjson" "^1.0.1"
     iconv-lite "^0.6.2"


### PR DESCRIPTION
Fixes #78 

This PR adds the following:

* a "Click to show all" button which allows the showing of games which have been filtered due to being less than 30 seconds
* the ability to reveal a file in the default file explorer when clicking on the file name

The setting is stored in the local component state which means the option to filter/show is reset back to the default (which is to filter) whenever the component is unmounted.

### Screenshot

![screenshot](https://i.imgur.com/ynp7ySJ.png)