### PR TITLE
Add .nvmrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ coverage
 # node-waf configuration
 .lock-wscript
 
+# nvm configuration
+.nvmrc
+
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 .eslintcache


### PR DESCRIPTION
The `.nvmrc` file is used by the popular Node version manager [nvm](https://github.com/nvm-sh/nvm). For instance, if its contents are
```
10.22.0
```
then running `nvm use` from the repo root will switch the Node version to 10.22.0.