### PR TITLE
First pass at signing the desktop app for macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,18 @@ jobs:
             playback_image: macOS-playback
             playback_dolphin_path: app/dolphin-dev/osx/
     steps:
+      - name: Load macOS signing certificates and secrets
+        if: matrix.os == 'macOS-latest'
+        run: |
+          chmod +x build/load-macos-certs-ci.sh && ./build/load-macos-certs-ci.sh
+          mkdir -p ~/private_keys/
+          echo '${{ secrets.APPLE_CONNECT_API_KEY }}' > ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
+        env:
+          CSC_LINK: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
+          CSC_KEY_PASSWORD: ${{ secrets.CERTIFICATE_MACOS_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
+          APPLE_TEAM_PROVIDER_ID: ${{ secrets.APPLE_TEAM_PROVIDER_ID }}
       - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,8 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
           APPLE_TEAM_PROVIDER_ID: ${{ secrets.APPLE_TEAM_PROVIDER_ID }}
+          CERTIFICATE_MACOS_APPLICATION: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
+          CERTIFICATE_MACOS_PASSWORD: ${{ secrets.CERTIFICATE_MACOS_PASSWORD }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,18 +26,6 @@ jobs:
             playback_image: macOS-playback
             playback_dolphin_path: app/dolphin-dev/osx/
     steps:
-      - name: Load macOS signing certificates and secrets
-        if: matrix.os == 'macOS-latest'
-        run: |
-          chmod +x build/load-macos-certs-ci.sh && ./build/load-macos-certs-ci.sh
-          mkdir -p ~/private_keys/
-          echo '${{ secrets.APPLE_CONNECT_API_KEY }}' > ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
-        env:
-          CSC_LINK: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
-          CSC_KEY_PASSWORD: ${{ secrets.CERTIFICATE_MACOS_PASSWORD }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
-          APPLE_TEAM_PROVIDER_ID: ${{ secrets.APPLE_TEAM_PROVIDER_ID }}
       - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
         uses: actions/setup-node@v1
         with:
@@ -62,6 +50,18 @@ jobs:
             ${{ runner.OS }}-build-${{ env.cache-name }}-
             ${{ runner.OS }}-build-
             ${{ runner.OS }}-
+      - name: Load macOS signing certificates and secrets
+        if: matrix.os == 'macOS-latest'
+        run: |
+          chmod +x build/load-macos-certs-ci.sh && ./build/load-macos-certs-ci.sh
+          mkdir -p ~/private_keys/
+          echo '${{ secrets.APPLE_CONNECT_API_KEY }}' > ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
+        env:
+          CSC_LINK: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
+          CSC_KEY_PASSWORD: ${{ secrets.CERTIFICATE_MACOS_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
+          APPLE_TEAM_PROVIDER_ID: ${{ secrets.APPLE_TEAM_PROVIDER_ID }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,8 @@ jobs:
           chmod +x build/load-macos-certs-ci.sh && ./build/load-macos-certs-ci.sh
           mkdir -p ~/private_keys/
           echo '${{ secrets.APPLE_CONNECT_API_KEY }}' > ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
+          echo "CSC_LINK=${{ secrets.CERTIFICATE_MACOS_APPLICATION }}" >> $GITHUB_ENV
+          echo "CSC_KEY_PASSWORD=${{ secrets.CERTIFICATE_MACOS_PASSWORD }}" >> $GITHUB_ENV
           echo "APPLE_API_KEY=${{ secrets.APPLE_API_KEY_ID }}" >> $GITHUB_ENV
           echo "APPLE_ISSUER_ID=${{ secrets.APPLE_ISSUER_ID }}" >> $GITHUB_ENV
           echo "APPLE_TEAM_PROVIDER_ID=${{ secrets.APPLE_TEAM_PROVIDER_ID }}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,8 +56,6 @@ jobs:
           chmod +x build/load-macos-certs-ci.sh && ./build/load-macos-certs-ci.sh
           mkdir -p ~/private_keys/
           echo '${{ secrets.APPLE_CONNECT_API_KEY }}' > ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
-          echo "CSC_LINK=${{ secrets.CERTIFICATE_MACOS_APPLICATION }}" >> $GITHUB_ENV
-          echo "CSC_KEY_PASSWORD=${{ secrets.CERTIFICATE_MACOS_PASSWORD }}" >> $GITHUB_ENV
           echo "APPLE_API_KEY=${{ secrets.APPLE_API_KEY_ID }}" >> $GITHUB_ENV
           echo "APPLE_ISSUER_ID=${{ secrets.APPLE_ISSUER_ID }}" >> $GITHUB_ENV
           echo "APPLE_TEAM_PROVIDER_ID=${{ secrets.APPLE_TEAM_PROVIDER_ID }}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,5 +99,4 @@ jobs:
         uses: actions/upload-artifact@v2-preview
         with:
           name: ${{ matrix.os }}
-          path: "./artifact/"
           path: './artifact/'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
             ${{ runner.OS }}-build-
             ${{ runner.OS }}-
       - name: Load macOS signing certificates and secrets
-        if: matrix.os == 'macOS-latest'
+        if: matrix.os == 'macOS-latest' && env.CERTIFICATE_MACOS_PASSWORD != null
         run: |
           chmod +x build/load-macos-certs-ci.sh && ./build/load-macos-certs-ci.sh
           mkdir -p ~/private_keys/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,12 +56,12 @@ jobs:
           chmod +x build/load-macos-certs-ci.sh && ./build/load-macos-certs-ci.sh
           mkdir -p ~/private_keys/
           echo '${{ secrets.APPLE_CONNECT_API_KEY }}' > ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
+          echo "CSC_LINK=${{ secrets.CERTIFICATE_MACOS_APPLICATION }}" >> $GITHUB_ENV
+          echo "CSC_KEY_PASSWORD=${{ secrets.CERTIFICATE_MACOS_PASSWORD }}" >> $GITHUB_ENV
+          echo "APPLE_API_KEY=${{ secrets.APPLE_API_KEY_ID }}" >> $GITHUB_ENV
+          echo "APPLE_ISSUER_ID=${{ secrets.APPLE_ISSUER_ID }}" >> $GITHUB_ENV
+          echo "APPLE_TEAM_PROVIDER_ID=${{ secrets.APPLE_TEAM_PROVIDER_ID }}" >> $GITHUB_ENV
         env:
-          CSC_LINK: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
-          CSC_KEY_PASSWORD: ${{ secrets.CERTIFICATE_MACOS_PASSWORD }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
-          APPLE_TEAM_PROVIDER_ID: ${{ secrets.APPLE_TEAM_PROVIDER_ID }}
           CERTIFICATE_MACOS_APPLICATION: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
           CERTIFICATE_MACOS_PASSWORD: ${{ secrets.CERTIFICATE_MACOS_PASSWORD }}
       - name: Install dependencies

--- a/build/afterSignHook.macos.js
+++ b/build/afterSignHook.macos.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+var electron_notarize = require('electron-notarize');
+
+module.exports = async function (params) {
+    if(process.platform !== 'darwin') {
+        return;
+    }
+
+    console.log('afterSign hook triggered', params);
+
+    // Bail early if this is a fork-caused PR build, which doesn't get
+    // secrets.
+    if(
+        !process.env.APPLE_TEAM_PROVIDER_ID || 
+        !process.env.APPLE_API_KEY || 
+        !process.env.APPLE_ISSUER_ID
+    ) {
+        console.log("Bailing, no secrets found.");
+        return;
+    }
+
+    let appId = 'com.github.projectslippi.slippidesktopapp';
+    let appPath = path.join(params.appOutDir, `${params.packager.appInfo.productFilename}.app`);
+    if (!fs.existsSync(appPath)) {
+        throw new Error(`Cannot find application at: ${appPath}`);
+    }
+
+    console.log(`Notarizing ${appId} found at ${appPath} (this could take awhile, get some coffee...)`);
+
+    try {
+        await electron_notarize.notarize({
+            appBundleId: appId,
+            appPath: appPath,
+            ascProvider: process.env.APPLE_TEAM_PROVIDER_ID,
+            appleApiKey: process.env.APPLE_API_KEY,
+            appleApiIssuer: process.env.APPLE_ISSUER_ID,
+        });
+
+        console.log(`Successfully notarized ${appId}`);
+    } catch (error) {
+        console.error(error);
+    }
+};

--- a/build/afterSignHook.macos.js
+++ b/build/afterSignHook.macos.js
@@ -32,7 +32,6 @@ module.exports = async function (params) {
         await electron_notarize.notarize({
             appBundleId: appId,
             appPath: appPath,
-            ascProvider: process.env.APPLE_TEAM_PROVIDER_ID,
             appleApiKey: process.env.APPLE_API_KEY,
             appleApiIssuer: process.env.APPLE_ISSUER_ID,
         });

--- a/build/entitlements.macos.plist
+++ b/build/entitlements.macos.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.cs.allow-jit</key>
+        <true />
+        <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+        <true />
+        <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+        <true />
+        <key>com.apple.security.cs.disable-executable-page-protection</key>
+        <true />
+        <key>com.apple.security.automation.apple-events</key>
+        <true />
+    </dict>
+</plist>

--- a/build/entitlements.macos.plist
+++ b/build/entitlements.macos.plist
@@ -3,14 +3,14 @@
 <plist version="1.0">
     <dict>
         <key>com.apple.security.cs.allow-jit</key>
-        <true />
+        <true/>
         <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-        <true />
+        <true/>
         <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-        <true />
+        <true/>
         <key>com.apple.security.cs.disable-executable-page-protection</key>
-        <true />
+        <true/>
         <key>com.apple.security.automation.apple-events</key>
-        <true />
+        <true/>
     </dict>
 </plist>

--- a/build/load-macos-certs-ci.sh
+++ b/build/load-macos-certs-ci.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+KEY_CHAIN=build.keychain
+CERTIFICATE_P12=certificate.p12
+
+# Recreate the certificate from the secure environment variable
+echo $CERTIFICATE_MACOS_APPLICATION | base64 --decode > $CERTIFICATE_P12
+
+#create a keychain
+security create-keychain -p actions $KEY_CHAIN
+
+# Make the keychain the default so identities are found
+security default-keychain -s $KEY_CHAIN
+
+# Unlock the keychain
+security unlock-keychain -p actions $KEY_CHAIN
+
+security import $CERTIFICATE_P12 -k $KEY_CHAIN -P $CERTIFICATE_MACOS_PASSWORD -T /usr/bin/codesign;
+
+security set-key-partition-list -S apple-tool:,apple: -s -k actions $KEY_CHAIN
+
+# remove certs
+rm -fr *.p12

--- a/build/load-macos-certs-ci.sh
+++ b/build/load-macos-certs-ci.sh
@@ -6,18 +6,23 @@ CERTIFICATE_P12=certificate.p12
 # Recreate the certificate from the secure environment variable
 echo $CERTIFICATE_MACOS_APPLICATION | base64 --decode > $CERTIFICATE_P12
 
-#create a keychain
+# Create a temporary keychain
 security create-keychain -p actions $KEY_CHAIN
+
+# Remove the relock timeout, which can happen if our builds take forever.
+security set-keychain-settings $KEY_CHAIN
+
+# Import certificate
+security import $CERTIFICATE_P12 -k $KEY_CHAIN -P $CERTIFICATE_MACOS_PASSWORD -T /usr/bin/codesign;
+
+# Mark this as okay to be accessed from command line tools
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k actions $KEY_CHAIN
 
 # Make the keychain the default so identities are found
 security default-keychain -s $KEY_CHAIN
 
 # Unlock the keychain
 security unlock-keychain -p actions $KEY_CHAIN
-
-security import $CERTIFICATE_P12 -k $KEY_CHAIN -P $CERTIFICATE_MACOS_PASSWORD -T /usr/bin/codesign;
-
-security set-key-partition-list -S apple-tool:,apple: -s -k actions $KEY_CHAIN
 
 # remove certs
 rm -fr *.p12

--- a/package.json
+++ b/package.json
@@ -265,7 +265,6 @@
     "electron-debug": "^2.0.0",
     "electron-log": "^2.2.17",
     "electron-settings": "^3.2.0",
-    "electron-sudo": "^4.0.12",
     "electron-updater": "^4.0.6",
     "firebase": "^7.20.0",
     "fs-extra": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "build": {
     "productName": "Slippi Launcher",
     "appId": "com.github.projectslippi.slippidesktopapp",
+    "afterSign": "./build/afterSignHook.macos.js",
     "asarUnpack": [
       "**/dolphin/**/*",
       "**/images/**/*",
@@ -83,7 +84,6 @@
       },
       "hardenedRuntime": true,
       "entitlements": "./build/entitlements.macos.plist",
-      "afterSign": "./build/afterSignHook.macos.js",
       "category": "public.app-category.video",
       "target": [
         "zip",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,10 @@
         "role": "viewer",
         "icon": "./resources/file.icns"
       },
-      "category": "your.app.category.type",
+      "hardenedRuntime": true,
+      "entitlements": "./build/entitlements.macos.plist",
+      "afterSign": "./build/afterSignHook.macos.js",
+      "category": "public.app-category.video",
       "target": [
         "zip",
         "dmg"
@@ -205,6 +208,7 @@
     "electron": "^4.1.4",
     "electron-builder": "^22.8.0",
     "electron-devtools-installer": "^2.2.4",
+    "electron-notarize": "^1.0.0",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",
     "enzyme-to-json": "^3.3.4",


### PR DESCRIPTION
Yeah, I know this PR is coming from a weird spot, but it needs access to actions secrets for testing.

Threads various environment variables/electron-bundler configurations for signing and notarizing the application for macOS. This might take a few passes to get correct and should just be squashed when eventually merged.