### PR TITLE
Enable arbitrary loads for auto updater to work on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,12 @@
       "category": "public.app-category.video",
       "target": [
         "dmg"
-      ]
+      ],
+      "extendInfo": {
+        "NSAppTransportSecurity": {
+          "NSAllowsArbitraryLoads": true
+        }
+      }
     },
     "win": {
       "target": [

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
       "entitlements": "./build/entitlements.macos.plist",
       "category": "public.app-category.video",
       "target": [
-        "dmg"
+        "dmg",
+        "zip"
       ],
       "extendInfo": {
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Transition to hardened runtime needs this; probably a more restrictive way to do it, can investigate that in the future.