### PR TITLE
-hs -> --hide-seekbar

### DIFF
--- a/app/domain/DolphinManager.js
+++ b/app/domain/DolphinManager.js
@@ -247,7 +247,7 @@ export default class DolphinManager extends EventEmitter {
     ];
 
     if (this.settings.mode === "mirror") {
-      args = args.concat(['-hs']);
+      args = args.concat(['--hide-seekbar']);
     }
 
     if (startPlayback) {


### PR DESCRIPTION
Mainline dolphin's CLI parsing library disallows multi letter flags, so this works for both and prevents broken launches on Mainline