### PR TITLE
Generified sorting to allow for arbitrary sorting strategies 

### DIFF
--- a/src/common/replayBrowser/processGame.ts
+++ b/src/common/replayBrowser/processGame.ts
@@ -3,6 +3,7 @@ import { SlippiGame } from "@slippi/slippi-js";
 import path from "path";
 import { FileResult } from "./types";
 import { fileToDateAndTime } from "../time";
+import SlippiGame from "@slippi/slippi-js";
 
 export async function processGame(fullPath: string): Promise<FileResult> {
   const filename = path.basename(fullPath);
@@ -20,6 +21,8 @@ export async function processGame(fullPath: string): Promise<FileResult> {
     startTime: null,
     lastFrame: null,
     metadata: null,
+    // stats: null,
+    // latestFrame: null,
   };
 
   // Load metadata
@@ -42,5 +45,16 @@ export async function processGame(fullPath: string): Promise<FileResult> {
     result.startTime = startAtTime.toISOString();
   }
 
+  // // Load stats
+  // const stats = game.getStats();
+  // if (stats) {
+  //   result.stats = stats;
+  // }
+
+  // // Load latestFrame
+  // const latestFrameDetails = game.getLatestFrame(); // TODO this is way too slow to put here...
+  // if (latestFrameDetails) {
+  //   result.latestFrameDetails = latestFrameDetails;
+  // }
   return result;
 }

--- a/src/common/replayBrowser/processGame.ts
+++ b/src/common/replayBrowser/processGame.ts
@@ -3,7 +3,6 @@ import { SlippiGame } from "@slippi/slippi-js";
 import path from "path";
 import { FileResult } from "./types";
 import { fileToDateAndTime } from "../time";
-import SlippiGame from "@slippi/slippi-js";
 
 export async function processGame(fullPath: string): Promise<FileResult> {
   const filename = path.basename(fullPath);

--- a/src/common/replayBrowser/types.ts
+++ b/src/common/replayBrowser/types.ts
@@ -1,5 +1,4 @@
-import SlippiGame from "@slippi/slippi-js";
-import { StatsType, MetadataType, GameStartType } from "@slippi/slippi-js";
+import { MetadataType, GameStartType } from "@slippi/slippi-js";
 
 export interface FileResult {
   name: string;

--- a/src/common/replayBrowser/types.ts
+++ b/src/common/replayBrowser/types.ts
@@ -1,4 +1,5 @@
-import { MetadataType, GameStartType } from "@slippi/slippi-js";
+import SlippiGame from "@slippi/slippi-js";
+import { StatsType, MetadataType, GameStartType } from "@slippi/slippi-js";
 
 export interface FileResult {
   name: string;
@@ -7,6 +8,8 @@ export interface FileResult {
   startTime: string | null;
   lastFrame: number | null;
   metadata: MetadataType | null;
+  // stats: StatsType | null; // TODO calculating full stats is too slow to do on everything on load... remove this
+  // latestFrame: any | null; //This is also slow...
 }
 
 export interface FolderResult {

--- a/src/renderer/containers/ReplayBrowser/FileList.tsx
+++ b/src/renderer/containers/ReplayBrowser/FileList.tsx
@@ -84,9 +84,7 @@ const FilterToolbar: React.FC<{
   onChange: (value: FilterOptions) => void;
 }> = (props) => {
   const [tag, setTag] = React.useState<string>(props.value.tag);
-  const [setSortStrategy] = React.useState<Function>(
-    props.value.sortingStrategy
-  );
+  const [setSortStrategy] = React.useState<any>(props.value.sortingStrategy); // tried to make this (a: FileResult, b: FileResult) => number instead of any but react doesn't like that?
   const [hideShortGames, setHideShortGames] = React.useState<boolean>(
     props.value.hideShortGames
   );


### PR DESCRIPTION
Hey Bisneu!

What you will see in this PR is just a dumb group of radio buttons that let you sort by newest/oldest/length of match

My initial goal was to be able to sort by some complex stat like "highest kill percentage" after going through and adding I noticed the SlippiGame:getStats function was wayyyyyy too slow to run on every file at import time. I think this could definitely be made a thing with deferred or async execution. I don't want to step on anyone's toes though so if you would rather me work on stats instead I think that would be better. This draft PR can just be a place to maybe talk about getting some more complicated stats in the initial table view so we can sort/filter on them.

Maybe the angle to attack this is to work see if I can speed up the getStats function? I haven't really looked too hard at the .slp file type but it seems like we should be able to grab at least some data very quickly? Let me know if you think this is worth looking into.

Another way to have easier access to some complicated stats is if we save/calculate them as the game is running. This is just me spitballing and I'm sure it would have a crazy huge impact on the ecosystem... 

Anyway let me know what you think. I'm going to take a look into that stats page in the meantime. Are there any non obvious best practice guidelines you have people follow? Or anything else I should know before getting started?