### PR TITLE
Change broadcasting start time to a locale time string

### DIFF
--- a/app/components/Broadcast.js
+++ b/app/components/Broadcast.js
@@ -260,7 +260,7 @@ export default class Broadcast extends Component {
           />
           {this.renderButton()}
           <div className={styles['connection-details']}>
-            <div>Status: {isBroadcasting ? `Broadcasting since ${JSON.stringify(startTime)}` : endTime ? `Broadcast lasted ${(endTime - startTime) / 1000} seconds` : "Not broadcasting"}</div>
+            <div>Status: {isBroadcasting ? `Broadcasting since ${startTime.toLocaleString()}` : endTime ? `Broadcast lasted ${(endTime - startTime) / 1000} seconds` : "Not broadcasting"}</div>
             {this.renderStatusDisplay(dolphinConnectionStatus, "Dolphin ")}
             {this.renderStatusDisplay(slippiConnectionStatus, "Broadcast ")}
           </div>


### PR DESCRIPTION
When broadcasting, the start time is converted into a string using JSON.stringify, which turns the formatting into an ISO Date-Time format. Using a locale time string is more readable in this case.

### When using JSON.stringify(date): 
![When using JSON.stringify](https://user-images.githubusercontent.com/15684482/107473037-9f996100-6b35-11eb-8685-9b1def012030.png)

### When using date.toLocaleString(): 
![When using date.toLocaleString()](https://user-images.githubusercontent.com/15684482/107473072-b344c780-6b35-11eb-8a90-88cd8e82c2d0.png)
