### PR TITLE
Add spectator functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,4 @@ main.js.map
 .idea
 npm-debug.log.*
 
-dolphin/
-
 .env

--- a/src/common/dolphin.ts
+++ b/src/common/dolphin.ts
@@ -1,4 +1,5 @@
 import { app, remote } from "electron";
+import electronSettings from "electron-settings";
 import * as fs from "fs-extra";
 import path from "path";
 
@@ -14,14 +15,22 @@ export enum DolphinUseType {
   NETPLAY = "netplay",
 }
 
-export async function findDolphinExecutable(type: DolphinLaunchType): Promise<string> {
-  // Make sure the directory actually exists
+export function getDefaultDolphinPath(type: DolphinLaunchType): string {
   let dolphinPath = "";
   try {
     dolphinPath = path.join(app.getPath("userData"), type);
   } catch {
     dolphinPath = path.join(remote.app.getPath("userData"), type);
   }
+  return dolphinPath;
+}
+
+export async function findDolphinExecutable(type: DolphinLaunchType | string, dolphinPath = ""): Promise<string> {
+  // Make sure the directory actually exists
+  if (dolphinPath === "") {
+    dolphinPath = (await electronSettings.get(`settings.${type}.path`)) as string;
+  }
+
   await fs.ensureDir(dolphinPath);
 
   // Check the directory contents

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -43,3 +43,12 @@ export interface StartBroadcastConfig {
   viewerId: string;
   authToken: string;
 }
+
+export interface BroadcasterItem {
+  broadcaster: {
+    name: string;
+    uid: string;
+  };
+  id: string;
+  name: string;
+}

--- a/src/main/dolphin/index.ts
+++ b/src/main/dolphin/index.ts
@@ -1,0 +1,2 @@
+export * from "./instance";
+export * from "./types";

--- a/src/main/dolphin/index.ts
+++ b/src/main/dolphin/index.ts
@@ -1,2 +1,3 @@
 export * from "./instance";
+export * from "./manager";
 export * from "./types";

--- a/src/main/dolphin/instance.ts
+++ b/src/main/dolphin/instance.ts
@@ -1,0 +1,85 @@
+import { ChildProcessWithoutNullStreams, spawn } from "child_process";
+import { fileExists } from "common/utils";
+import { randomBytes } from "crypto";
+import { app } from "electron";
+import { EventEmitter } from "events";
+import * as fs from "fs-extra";
+import path from "path";
+
+import { ReplayCommunication } from "./types";
+
+const generateTempCommunicationFile = (): string => {
+  const tmpDir = app.getPath("temp");
+  const uniqueId = randomBytes(12).toString("hex");
+  const commFileName = `slippi-comms-${uniqueId}.json`;
+  const commFileFullPath = path.join(tmpDir, commFileName);
+  return commFileFullPath;
+};
+
+export class NetplayDolphinInstance extends EventEmitter {
+  protected process: ChildProcessWithoutNullStreams | null = null;
+  private executablePath: string;
+  private isoPath: string | null = null;
+
+  public constructor(execPath: string, isoPath?: string) {
+    super();
+    this.isoPath = isoPath ?? null;
+    this.executablePath = execPath;
+  }
+
+  /***
+   * Spawns the Dolphin instance with any additional command line parameters
+   */
+  public start(additionalParams?: string[]) {
+    const params: string[] = [];
+
+    // Auto-start the ISO if provided
+    if (this.isoPath) {
+      params.push("-b", "-e", this.isoPath);
+    }
+
+    // Add additional params if necessary
+    if (additionalParams && additionalParams.length > 0) {
+      params.push(...additionalParams);
+    }
+
+    this.process = spawn(this.executablePath, params);
+    this.process.on("close", () => {
+      this.emit("close");
+    });
+  }
+}
+
+export class PlaybackDolphinInstance extends NetplayDolphinInstance {
+  private commPath: string;
+
+  public constructor(execPath: string, isoPath?: string) {
+    super(execPath, isoPath);
+    this.commPath = generateTempCommunicationFile();
+
+    // Delete the comm file once Dolphin is closed
+    this.on("close", () => {
+      fileExists(this.commPath).then((exists) => {
+        if (exists) {
+          fs.unlink(this.commPath);
+        }
+      });
+    });
+  }
+
+  /***
+   * Starts Dolphin with the specified replay communication options
+   */
+  public async play(options: ReplayCommunication) {
+    // Write out the comms file
+    await fs.writeFile(this.commPath, JSON.stringify(options));
+
+    if (!this.process) {
+      const params: string[] = [];
+      // Launch this comms file
+      params.push("-i", this.commPath);
+
+      this.start(params);
+    }
+  }
+}

--- a/src/main/dolphin/instance.ts
+++ b/src/main/dolphin/instance.ts
@@ -16,7 +16,7 @@ const generateTempCommunicationFile = (): string => {
   return commFileFullPath;
 };
 
-export class NetplayDolphinInstance extends EventEmitter {
+export class DolphinInstance extends EventEmitter {
   protected process: ChildProcessWithoutNullStreams | null = null;
   private executablePath: string;
   private isoPath: string | null = null;
@@ -50,7 +50,7 @@ export class NetplayDolphinInstance extends EventEmitter {
   }
 }
 
-export class PlaybackDolphinInstance extends NetplayDolphinInstance {
+export class PlaybackDolphinInstance extends DolphinInstance {
   private commPath: string;
 
   public constructor(execPath: string, isoPath?: string) {

--- a/src/main/dolphin/manager.ts
+++ b/src/main/dolphin/manager.ts
@@ -2,7 +2,7 @@ import { DolphinLaunchType, findDolphinExecutable } from "common/dolphin";
 import electronSettings from "electron-settings";
 import { EventEmitter } from "events";
 
-import { NetplayDolphinInstance, PlaybackDolphinInstance, ReplayCommunication } from "./dolphin";
+import { DolphinInstance, PlaybackDolphinInstance, ReplayCommunication } from ".";
 
 electronSettings.configure({
   fileName: "Settings",
@@ -13,7 +13,7 @@ electronSettings.configure({
 // This includes playing netplay, viewing replays, watching broadcasts (spectating), and configuring Dolphin.
 export class DolphinManager extends EventEmitter {
   private playbackDolphinInstances = new Map<string, PlaybackDolphinInstance>();
-  private netplayDolphinInstance: NetplayDolphinInstance | null = null;
+  private netplayDolphinInstance: DolphinInstance | null = null;
 
   public async launchPlaybackDolphin(id: string, replayComm: ReplayCommunication, metadata?: any): Promise<void> {
     const dolphinPath = await findDolphinExecutable(DolphinLaunchType.PLAYBACK);
@@ -38,7 +38,7 @@ export class DolphinManager extends EventEmitter {
     const dolphinPath = await findDolphinExecutable(DolphinLaunchType.NETPLAY);
     const meleeISOPath = (await electronSettings.get("settings.isoPath")) as string | undefined;
     if (!this.netplayDolphinInstance) {
-      this.netplayDolphinInstance = new NetplayDolphinInstance(dolphinPath, meleeISOPath);
+      this.netplayDolphinInstance = new DolphinInstance(dolphinPath, meleeISOPath);
       this.netplayDolphinInstance.on("close", () => {
         this.netplayDolphinInstance = null;
       });
@@ -47,7 +47,7 @@ export class DolphinManager extends EventEmitter {
 
   public async configureDolphin(launchType: DolphinLaunchType) {
     const dolphinPath = await findDolphinExecutable(launchType);
-    const instance = new NetplayDolphinInstance(dolphinPath);
+    const instance = new DolphinInstance(dolphinPath);
     instance.start();
   }
 }

--- a/src/main/dolphin/manager.ts
+++ b/src/main/dolphin/manager.ts
@@ -1,7 +1,9 @@
 import { DolphinLaunchType, findDolphinExecutable } from "common/dolphin";
+import log from "electron-log";
 import electronSettings from "electron-settings";
 import { EventEmitter } from "events";
 
+import { downloadAndInstallDolphin } from "../downloadDolphin";
 import { DolphinInstance, PlaybackDolphinInstance } from "./instance";
 import { ReplayCommunication } from "./types";
 
@@ -20,6 +22,10 @@ export class DolphinManager extends EventEmitter {
     const dolphinPath = await findDolphinExecutable(DolphinLaunchType.PLAYBACK);
     const meleeISOPath = (await electronSettings.get("settings.isoPath")) as string | undefined;
 
+    const configuring = this.playbackDolphinInstances.get("configure");
+    if (configuring) {
+      log.warn("cannot open dolphin if a configuring dolphin is open");
+    }
     let playbackInstance = this.playbackDolphinInstances.get(id);
     if (!playbackInstance) {
       playbackInstance = new PlaybackDolphinInstance(dolphinPath, meleeISOPath);
@@ -43,13 +49,52 @@ export class DolphinManager extends EventEmitter {
       this.netplayDolphinInstance.on("close", () => {
         this.netplayDolphinInstance = null;
       });
+    } else {
+      log.warn("cannot open netplay dolphin twice");
     }
   }
 
   public async configureDolphin(launchType: DolphinLaunchType) {
     const dolphinPath = await findDolphinExecutable(launchType);
-    const instance = new DolphinInstance(dolphinPath);
-    instance.start();
+    if (launchType === DolphinLaunchType.NETPLAY && !this.netplayDolphinInstance) {
+      const instance = new DolphinInstance(dolphinPath);
+      this.netplayDolphinInstance = instance;
+      this.netplayDolphinInstance.on("close", () => {
+        this.netplayDolphinInstance = null;
+      });
+      instance.start();
+    } else if (launchType === DolphinLaunchType.PLAYBACK && this.playbackDolphinInstances.size === 0) {
+      const instance = new PlaybackDolphinInstance(dolphinPath);
+      this.playbackDolphinInstances.set("configure", instance);
+      instance.on("close", () => {
+        this.emit("dolphin-closed", "configure");
+
+        // Remove the instance from the map on close
+        this.playbackDolphinInstances.delete("configure");
+      });
+      instance.start();
+    }
+  }
+
+  public async reinstallDolphin(launchType: DolphinLaunchType) {
+    switch (launchType) {
+      case DolphinLaunchType.NETPLAY: {
+        if (this.netplayDolphinInstance !== null) {
+          log.warn("A netplay dolphin is open");
+          return;
+        }
+        break;
+      }
+      case DolphinLaunchType.PLAYBACK: {
+        if (this.playbackDolphinInstances.size > 0) {
+          log.warn("A playback dolphin is open");
+          return;
+        }
+        break;
+      }
+    }
+    // No dolphins of launchType are open so lets reinstall
+    downloadAndInstallDolphin(launchType, log.info, true);
   }
 }
 

--- a/src/main/dolphin/manager.ts
+++ b/src/main/dolphin/manager.ts
@@ -16,7 +16,7 @@ export class DolphinManager extends EventEmitter {
   private playbackDolphinInstances = new Map<string, PlaybackDolphinInstance>();
   private netplayDolphinInstance: DolphinInstance | null = null;
 
-  public async launchPlaybackDolphin(id: string, replayComm: ReplayCommunication, metadata?: any): Promise<void> {
+  public async launchPlaybackDolphin(id: string, replayComm: ReplayCommunication): Promise<void> {
     const dolphinPath = await findDolphinExecutable(DolphinLaunchType.PLAYBACK);
     const meleeISOPath = (await electronSettings.get("settings.isoPath")) as string | undefined;
 
@@ -24,10 +24,7 @@ export class DolphinManager extends EventEmitter {
     if (!playbackInstance) {
       playbackInstance = new PlaybackDolphinInstance(dolphinPath, meleeISOPath);
       playbackInstance.on("close", () => {
-        this.emit("dolphin-closed", {
-          id,
-          metadata,
-        });
+        this.emit("dolphin-closed", id);
 
         // Remove the instance from the map on close
         this.playbackDolphinInstances.delete(id);

--- a/src/main/dolphin/manager.ts
+++ b/src/main/dolphin/manager.ts
@@ -27,6 +27,9 @@ export class DolphinManager extends EventEmitter {
           id,
           metadata,
         });
+
+        // Remove the instance from the map on close
+        this.playbackDolphinInstances.delete(id);
       });
       this.playbackDolphinInstances.set(id, playbackInstance);
     }

--- a/src/main/dolphin/manager.ts
+++ b/src/main/dolphin/manager.ts
@@ -2,7 +2,8 @@ import { DolphinLaunchType, findDolphinExecutable } from "common/dolphin";
 import electronSettings from "electron-settings";
 import { EventEmitter } from "events";
 
-import { DolphinInstance, PlaybackDolphinInstance, ReplayCommunication } from ".";
+import { DolphinInstance, PlaybackDolphinInstance } from "./instance";
+import { ReplayCommunication } from "./types";
 
 electronSettings.configure({
   fileName: "Settings",

--- a/src/main/dolphin/types.ts
+++ b/src/main/dolphin/types.ts
@@ -1,0 +1,20 @@
+export interface ReplayCommunication {
+  mode: "normal" | "mirror" | "queue"; // default normal
+  replay?: string; // path to the replay if in normal or mirror mode
+  startFrame?: number; // when to start watching the replay
+  endFrame?: number; // when to stop watching the replay
+  commandId?: string; // random string, doesn't really matter
+  outputOverlayFiles?: boolean; // outputs gameStartAt and gameStation to text files (only works in queue mode)
+  isRealTimeMode?: boolean; // default true; keeps dolphin fairly close to real time (about 2-3 frames); only relevant in mirror mode
+  shouldResync?: boolean; // default true; disables the resync functionality
+  rollbackDisplayMethod?: "off" | "normal" | "visible"; // default off; normal shows like a player experienced it, visible shows ALL frames (normal and rollback)
+  queue?: ReplayQueueItem[];
+}
+
+export interface ReplayQueueItem {
+  path: string;
+  startFrame?: number;
+  endFrame?: number;
+  gameStartAt?: string;
+  gameStation?: string;
+}

--- a/src/main/dolphinManager.ts
+++ b/src/main/dolphinManager.ts
@@ -1,217 +1,55 @@
-import { ChildProcessWithoutNullStreams, spawn } from "child_process";
-import { DolphinLaunchType, DolphinUseType, findDolphinExecutable } from "common/dolphin";
-import { randomBytes } from "crypto";
-import { app } from "electron";
+import { DolphinLaunchType, findDolphinExecutable } from "common/dolphin";
 import electronSettings from "electron-settings";
 import { EventEmitter } from "events";
-import * as fs from "fs-extra";
-import { find, remove } from "lodash";
-import path from "path";
 
-import { DolphinInstance } from "./types";
+import { NetplayDolphinInstance, PlaybackDolphinInstance, ReplayCommunication } from "./dolphin";
 
 electronSettings.configure({
   fileName: "Settings",
   prettify: true,
 });
 
-export interface ReplayCommunication {
-  mode: "normal" | "mirror" | "queue"; // default normal
-  replay?: string; // path to the replay if in normal or mirror mode
-  startFrame?: number; // when to start watching the replay
-  endFrame?: number; // when to stop watching the replay
-  commandId?: string; // random string, doesn't really matter
-  outputOverlayFiles?: boolean; // outputs gameStartAt and gameStation to text files (only works in queue mode)
-  isRealTimeMode?: boolean; // default true; keeps dolphin fairly close to real time (about 2-3 frames); only relevant in mirror mode
-  shouldResync?: boolean; // default true; disables the resync functionality
-  rollbackDisplayMethod?: "off" | "normal" | "visible"; // default off; normal shows like a player experienced it, visible shows ALL frames (normal and rollback)
-  queue?: ReplayQueueItem[];
-}
-
-export interface ReplayQueueItem {
-  path: string;
-  startFrame?: number;
-  endFrame?: number;
-  gameStartAt?: string;
-  gameStation?: string;
-}
-
-interface DolphinInstances {
-  playback: DolphinInstance | null;
-  spectate: DolphinInstance[] | null;
-  netplay: DolphinInstance | null;
-  configNetplay: DolphinInstance | null;
-  configPlayback: DolphinInstance | null;
-}
-
-async function generateCommunicationFilePath(dolphinUseType: DolphinUseType): Promise<string> {
-  const tmpDir = app.getPath("temp");
-  const uniqueId = randomBytes(3 * 4).toString("hex");
-  const commFileName = `slippi-${dolphinUseType}-${uniqueId}.txt`;
-  const commFileFullPath = path.join(tmpDir, commFileName);
-
-  return commFileFullPath;
-}
-
-async function startDolphin(
-  dolphinType: DolphinLaunchType,
-  commFilePath?: string,
-  additionalParams?: string[],
-): Promise<ChildProcessWithoutNullStreams> {
-  const dolphinPath = await findDolphinExecutable(dolphinType);
-
-  const params = [];
-  if (commFilePath) {
-    params.push("-i", commFilePath);
-  }
-  if (additionalParams) {
-    params.push(...additionalParams);
-  }
-  return spawn(dolphinPath, params);
-}
-
 // DolphinManager should be in control of all dolphin instances that get opened for actual use.
 // This includes playing netplay, viewing replays, watching broadcasts (spectating), and configuring Dolphin.
 export class DolphinManager extends EventEmitter {
-  private static instance: DolphinManager;
+  private playbackDolphinInstances = new Map<string, PlaybackDolphinInstance>();
+  private netplayDolphinInstance: NetplayDolphinInstance | null = null;
 
-  // max instances: playback, config, netplay - 1 | spectate - "infinite"
-  private dolphinInstances: DolphinInstances = {
-    playback: null,
-    spectate: null,
-    netplay: null,
-    configNetplay: null,
-    configPlayback: null,
-  };
+  public async launchPlaybackDolphin(id: string, replayComm: ReplayCommunication, metadata?: any): Promise<void> {
+    const dolphinPath = await findDolphinExecutable(DolphinLaunchType.PLAYBACK);
+    const meleeISOPath = (await electronSettings.get("settings.isoPath")) as string | undefined;
 
-  public static getInstance(): DolphinManager {
-    if (!DolphinManager.instance) {
-      DolphinManager.instance = new DolphinManager();
+    let playbackInstance = this.playbackDolphinInstances.get(id);
+    if (!playbackInstance) {
+      playbackInstance = new PlaybackDolphinInstance(dolphinPath, meleeISOPath);
+      playbackInstance.on("close", () => {
+        this.emit("dolphin-closed", {
+          id,
+          metadata,
+        });
+      });
+      this.playbackDolphinInstances.set(id, playbackInstance);
     }
-    return DolphinManager.instance;
+
+    playbackInstance.play(replayComm);
   }
 
-  public async launchDolphin(
-    dolphinUseType: DolphinUseType,
-    index: number,
-    replayComm?: ReplayCommunication,
-    dolphinType?: DolphinLaunchType,
-    broadcastId?: string,
-  ): Promise<void> {
-    // I hate how this is done
-    const isoParams: string[] = [];
-    const meleeISOPath = await electronSettings.get("settings.isoPath");
-    if (meleeISOPath?.toString()) {
-      isoParams.push("-b", "-e", meleeISOPath.toString());
+  public async launchNetplayDolphin() {
+    const dolphinPath = await findDolphinExecutable(DolphinLaunchType.NETPLAY);
+    const meleeISOPath = (await electronSettings.get("settings.isoPath")) as string | undefined;
+    if (!this.netplayDolphinInstance) {
+      this.netplayDolphinInstance = new NetplayDolphinInstance(dolphinPath, meleeISOPath);
+      this.netplayDolphinInstance.on("close", () => {
+        this.netplayDolphinInstance = null;
+      });
     }
+  }
 
-    switch (dolphinUseType) {
-      case DolphinUseType.PLAYBACK: {
-        if (!this.dolphinInstances.playback) {
-          const commFilePath = await generateCommunicationFilePath(dolphinUseType);
-
-          const dolphin = await startDolphin(DolphinLaunchType.PLAYBACK, commFilePath, isoParams);
-          this.dolphinInstances.playback = {
-            type: dolphinUseType,
-            dolphin: dolphin,
-            commFilePath: commFilePath,
-          };
-
-          dolphin.on("close", async () => {
-            await fs.unlink(commFilePath);
-            this.dolphinInstances.playback = null;
-          });
-        }
-
-        if (
-          this.dolphinInstances.playback.type === DolphinUseType.PLAYBACK &&
-          this.dolphinInstances.playback.commFilePath
-        ) {
-          await fs.writeFile(this.dolphinInstances.playback.commFilePath, JSON.stringify(replayComm));
-        }
-
-        break;
-      }
-
-      case DolphinUseType.SPECTATE: {
-        if (index < 0) {
-          throw Error("Must have a valid index");
-        }
-        let dolphinInstance: DolphinInstance | undefined = find(this.dolphinInstances.spectate, ["index", index]);
-        if (!dolphinInstance?.dolphin) {
-          const commFilePath = await generateCommunicationFilePath(dolphinUseType);
-          const dolphin = await startDolphin(DolphinLaunchType.PLAYBACK, commFilePath, isoParams);
-          dolphinInstance = {
-            type: dolphinUseType,
-            index: index,
-            commFilePath: commFilePath,
-            dolphin: dolphin,
-            broadcastId: broadcastId,
-          };
-
-          // create an array of DolphinInstances if this is our first time launching a spectator client
-          if (this.dolphinInstances.spectate === null) {
-            this.dolphinInstances.spectate = [dolphinInstance];
-          } else {
-            this.dolphinInstances.spectate.push(dolphinInstance);
-          }
-
-          dolphin.on("close", async () => {
-            this.emit("spectate-dolphin-closed", broadcastId);
-            await fs.unlink(commFilePath);
-            if (this.dolphinInstances.spectate) {
-              remove(
-                this.dolphinInstances.spectate,
-                (instance) => instance.type === DolphinUseType.SPECTATE && instance.index === index,
-              );
-            }
-          });
-        }
-        if (dolphinInstance.type === DolphinUseType.SPECTATE && dolphinInstance.commFilePath) {
-          await fs.writeFile(dolphinInstance.commFilePath, JSON.stringify(replayComm));
-        }
-
-        break;
-      }
-
-      case DolphinUseType.NETPLAY: {
-        if (!this.dolphinInstances.netplay) {
-          const dolphin = await startDolphin(DolphinLaunchType.NETPLAY, undefined, isoParams);
-          this.dolphinInstances.netplay = {
-            type: dolphinUseType,
-            dolphin: dolphin,
-          };
-
-          dolphin.on("close", () => {
-            this.dolphinInstances.netplay = null;
-          });
-        }
-
-        break;
-      }
-
-      case DolphinUseType.CONFIG: {
-        let configureType = "";
-        if (dolphinType === DolphinLaunchType.NETPLAY) {
-          configureType = "configNetplay";
-        } else if (dolphinType === DolphinLaunchType.PLAYBACK) {
-          configureType = "configPlayback";
-        } else {
-          throw Error("Must define a dolphin type for configuration");
-        }
-
-        const dolphin = await startDolphin(dolphinType);
-        this.dolphinInstances[configureType] = {
-          type: dolphinUseType,
-          dolphin: dolphin,
-        };
-
-        dolphin.on("close", () => {
-          this.dolphinInstances[configureType] = null;
-        });
-
-        break;
-      }
-    }
+  public async configureDolphin(launchType: DolphinLaunchType) {
+    const dolphinPath = await findDolphinExecutable(launchType);
+    const instance = new NetplayDolphinInstance(dolphinPath);
+    instance.start();
   }
 }
+
+export const dolphinManager = new DolphinManager();

--- a/src/main/listeners.ts
+++ b/src/main/listeners.ts
@@ -75,6 +75,6 @@ export function setupListeners() {
   });
 
   ipc.answerRenderer("watchBroadcast", async (broadcasterId: string) => {
-    spectateManager.watchBroadcast(broadcasterId);
+    spectateManager.watchBroadcast(broadcasterId, undefined, true);
   });
 }

--- a/src/main/listeners.ts
+++ b/src/main/listeners.ts
@@ -9,6 +9,9 @@ import { DolphinManager, ReplayCommunication } from "./dolphinManager";
 import { assertDolphinInstallations } from "./downloadDolphin";
 import { fetchNewsFeed } from "./newsFeed";
 import { worker as replayBrowserWorker } from "./replayBrowser/workerInterface";
+import { SpectateManager } from "./spectateManager";
+
+const spectateManager = new SpectateManager();
 
 export function setupListeners() {
   ipcMain.on("onDragStart", (event, filePath: string) => {
@@ -77,5 +80,16 @@ function setupDolphinManagerListeners() {
   ipc.answerRenderer("fetchNewsFeed", async () => {
     const result = await fetchNewsFeed();
     return result;
+  });
+
+  ipc.answerRenderer("fetchBroadcastList", async (authToken: string) => {
+    await spectateManager.connect(authToken);
+    const result = await spectateManager.fetchBroadcastList();
+    console.log("fetched broadcast list: ", result);
+    return result;
+  });
+
+  ipc.answerRenderer("watchBroadcast", async (broadcasterId: string) => {
+    spectateManager.watchBroadcast(broadcasterId);
   });
 }

--- a/src/main/listeners.ts
+++ b/src/main/listeners.ts
@@ -43,8 +43,14 @@ export function setupListeners() {
     dolphinManager.launchNetplayDolphin();
   });
 
-  ipcMain.on("configureDolphin", (_, dolphinType: DolphinLaunchType) => {
-    dolphinManager.configureDolphin(dolphinType);
+  ipc.answerRenderer("configureDolphin", async (dolphinType: DolphinLaunchType) => {
+    console.log("configuring dolphin...");
+    await dolphinManager.configureDolphin(dolphinType);
+  });
+
+  ipc.answerRenderer("reinstallDolphin", async (dolphinType: DolphinLaunchType) => {
+    console.log("reinstalling dolphin...");
+    await dolphinManager.reinstallDolphin(dolphinType);
   });
 
   ipc.answerRenderer("loadReplayFolder", async (folderPath: string) => {

--- a/src/main/listeners.ts
+++ b/src/main/listeners.ts
@@ -1,11 +1,12 @@
-import { DolphinLaunchType, DolphinUseType } from "common/dolphin";
+import { DolphinLaunchType } from "common/dolphin";
 import { StartBroadcastConfig } from "common/types";
 import { ipcMain, nativeImage } from "electron";
 import { ipcMain as ipc } from "electron-better-ipc";
 import path from "path";
 
 import { broadcastManager } from "./broadcastManager";
-import { DolphinManager, ReplayCommunication } from "./dolphinManager";
+import { ReplayCommunication } from "./dolphin";
+import { dolphinManager } from "./dolphinManager";
 import { assertDolphinInstallations } from "./downloadDolphin";
 import { fetchNewsFeed } from "./newsFeed";
 import { worker as replayBrowserWorker } from "./replayBrowser/workerInterface";
@@ -37,29 +38,20 @@ export function setupListeners() {
 }
 
 function setupDolphinManagerListeners() {
-  const dolphinManager = DolphinManager.getInstance();
   ipcMain.on("viewReplay", (_, filePath: string) => {
     const replayComm: ReplayCommunication = {
       mode: "normal",
       replay: filePath,
     };
-    dolphinManager.launchDolphin(DolphinUseType.PLAYBACK, -1, replayComm);
-  });
-
-  ipcMain.on("watchBroadcast", (_, filePath: string, mode: "normal" | "mirror", index: number) => {
-    const replayComm: ReplayCommunication = {
-      mode: mode,
-      replay: filePath,
-    };
-    dolphinManager.launchDolphin(DolphinUseType.SPECTATE, index, replayComm);
+    dolphinManager.launchPlaybackDolphin("playback", replayComm);
   });
 
   ipcMain.on("playNetplay", () => {
-    dolphinManager.launchDolphin(DolphinUseType.NETPLAY, -1);
+    dolphinManager.launchNetplayDolphin();
   });
 
   ipcMain.on("configureDolphin", (_, dolphinType: DolphinLaunchType) => {
-    dolphinManager.launchDolphin(DolphinUseType.CONFIG, -1, undefined, dolphinType);
+    dolphinManager.configureDolphin(dolphinType);
   });
 
   ipc.answerRenderer("loadReplayFolder", async (folderPath: string) => {

--- a/src/main/listeners.ts
+++ b/src/main/listeners.ts
@@ -9,9 +9,7 @@ import { dolphinManager, ReplayCommunication } from "./dolphin";
 import { assertDolphinInstallations } from "./downloadDolphin";
 import { fetchNewsFeed } from "./newsFeed";
 import { worker as replayBrowserWorker } from "./replayBrowser/workerInterface";
-import { SpectateManager } from "./spectateManager";
-
-const spectateManager = new SpectateManager();
+import { spectateManager } from "./spectateManager";
 
 export function setupListeners() {
   ipcMain.on("onDragStart", (event, filePath: string) => {
@@ -33,10 +31,6 @@ export function setupListeners() {
     broadcastManager.stop();
   });
 
-  setupDolphinManagerListeners();
-}
-
-function setupDolphinManagerListeners() {
   ipcMain.on("viewReplay", (_, filePath: string) => {
     const replayComm: ReplayCommunication = {
       mode: "normal",

--- a/src/main/listeners.ts
+++ b/src/main/listeners.ts
@@ -5,8 +5,7 @@ import { ipcMain as ipc } from "electron-better-ipc";
 import path from "path";
 
 import { broadcastManager } from "./broadcastManager";
-import { ReplayCommunication } from "./dolphin";
-import { dolphinManager } from "./dolphinManager";
+import { dolphinManager, ReplayCommunication } from "./dolphin";
 import { assertDolphinInstallations } from "./downloadDolphin";
 import { fetchNewsFeed } from "./newsFeed";
 import { worker as replayBrowserWorker } from "./replayBrowser/workerInterface";

--- a/src/main/spectateManager.ts
+++ b/src/main/spectateManager.ts
@@ -11,6 +11,8 @@ import { dolphinManager, ReplayCommunication } from "./dolphin";
 
 const SLIPPI_WS_SERVER = process.env.SLIPPI_WS_SERVER;
 
+const DOLPHIN_INSTANCE_ID = "spectate";
+
 export enum SpectateManagerEvent {
   ERROR = "error",
   BROADCAST_LIST_UPDATE = "broadcastListUpdate",
@@ -37,7 +39,7 @@ export class SpectateManager extends EventEmitter {
     // A connection can mirror its received gameplay
     dolphinManager.on("dolphin-closed", (data: { id: string; metadata: any }) => {
       const broadcastId = data.metadata;
-      if (data.id !== "spectate" || this.prevBroadcastId !== broadcastId) {
+      if (data.id !== DOLPHIN_INSTANCE_ID || this.prevBroadcastId !== broadcastId) {
         return;
       }
       log.info("[Spectator] dolphin closed");
@@ -75,7 +77,7 @@ export class SpectateManager extends EventEmitter {
       mode: "mirror",
       replay: filePath,
     };
-    dolphinManager.launchPlaybackDolphin("spectate", replayComm);
+    dolphinManager.launchPlaybackDolphin(DOLPHIN_INSTANCE_ID, replayComm);
   }
 
   private _handleEvents(obj: any) {
@@ -297,3 +299,5 @@ export class SpectateManager extends EventEmitter {
     this.prevBroadcastId = broadcastId;
   }
 }
+
+export const spectateManager = new SpectateManager();

--- a/src/main/spectateManager.ts
+++ b/src/main/spectateManager.ts
@@ -7,8 +7,7 @@ import * as fs from "fs-extra";
 import _ from "lodash";
 import { client as WebSocketClient, connection, IMessage } from "websocket";
 
-import { ReplayCommunication } from "./dolphin";
-import { dolphinManager } from "./dolphinManager";
+import { dolphinManager, ReplayCommunication } from "./dolphin";
 
 const SLIPPI_WS_SERVER = process.env.SLIPPI_WS_SERVER;
 

--- a/src/main/spectateManager.ts
+++ b/src/main/spectateManager.ts
@@ -25,7 +25,7 @@ export enum SpectateManagerEvent {
 export class SpectateManager extends EventEmitter {
   private prevBroadcastId: string | null;
   private gameStarted: boolean;
-  private cursorByBroadcast: any;
+  private cursorByBroadcast: Record<string, any>;
   private slpFileWriter: SlpFileWriter;
   private wsConnection: connection | null;
 

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -1,6 +1,4 @@
 import { DolphinMessageType } from "@slippi/slippi-js";
-import { ChildProcessWithoutNullStreams } from "child_process";
-import { DolphinUseType } from "common/dolphin";
 
 type TypeMap<M extends { [index: string]: any }> = {
   [Key in keyof M]: M[Key] extends undefined
@@ -30,24 +28,3 @@ type SlippiBroadcastEventPayload = {
 };
 
 export type SlippiBroadcastEvent = TypeMap<SlippiBroadcastEventPayload>[keyof TypeMap<SlippiBroadcastEventPayload>];
-
-type DolphinInstancePayload = {
-  [DolphinUseType.CONFIG]: {
-    dolphin?: ChildProcessWithoutNullStreams;
-  };
-  [DolphinUseType.NETPLAY]: {
-    dolphin?: ChildProcessWithoutNullStreams;
-  };
-  [DolphinUseType.PLAYBACK]: {
-    dolphin?: ChildProcessWithoutNullStreams;
-    commFilePath?: string;
-  };
-  [DolphinUseType.SPECTATE]: {
-    index?: number; // should refer to the index in relation to the list of sources for spectating
-    dolphin?: ChildProcessWithoutNullStreams;
-    commFilePath?: string;
-    broadcastId?: string; // only necessary for spectating dolphins
-  };
-};
-
-export type DolphinInstance = TypeMap<DolphinInstancePayload>[keyof TypeMap<DolphinInstancePayload>];

--- a/src/renderer/components/LoginNotice.tsx
+++ b/src/renderer/components/LoginNotice.tsx
@@ -1,0 +1,30 @@
+import Button from "@material-ui/core/Button";
+import Typography from "@material-ui/core/Typography";
+import PersonOutlineIcon from "@material-ui/icons/PersonOutline";
+import React from "react";
+import styled from "styled-components";
+
+import { useLoginModal } from "@/lib/hooks/useLoginModal";
+
+export const LoginNotice: React.FC = () => {
+  const openModal = useLoginModal((store) => store.openModal);
+  return (
+    <Outer>
+      <div>
+        <PersonOutlineIcon style={{ fontSize: 100 }} />
+      </div>
+      <Typography variant="h6">User is not logged in</Typography>
+      <Button type="button" color="primary" variant="contained" style={{ textTransform: "none" }} onClick={openModal}>
+        Log in
+      </Button>
+    </Outer>
+  );
+};
+
+const Outer = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/renderer/components/PrivateRoute.tsx
+++ b/src/renderer/components/PrivateRoute.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Route, RouteProps } from "react-router-dom";
+
+import { useApp } from "@/store/app";
+
+import { LoginNotice } from "./LoginNotice";
+
+export const PrivateRoute: React.FC<RouteProps> = ({ children, component: Component, ...rest }) => {
+  const user = useApp((store) => store.user);
+  const isLoggedIn = user !== null;
+
+  return (
+    <Route
+      {...rest}
+      render={(props) => {
+        if (!isLoggedIn) {
+          return <LoginNotice />;
+        }
+
+        if (!Component && children) {
+          return children;
+        }
+
+        if (Component) {
+          return <Component {...props} />;
+        }
+
+        return null;
+      }}
+    />
+  );
+};

--- a/src/renderer/containers/Header/UserMenu.tsx
+++ b/src/renderer/containers/Header/UserMenu.tsx
@@ -24,12 +24,14 @@ export const UserMenu: React.FC<{
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down("xs"));
   const onLogout = async () => {
-    handleClose();
-    await deletePlayKey();
     try {
       await firebase.auth().signOut();
+      await deletePlayKey();
     } catch (err) {
+      console.error(err);
       handleError(err);
+    } finally {
+      handleClose();
     }
   };
 

--- a/src/renderer/containers/Header/index.tsx
+++ b/src/renderer/containers/Header/index.tsx
@@ -1,14 +1,8 @@
 import Box from "@material-ui/core/Box";
 import Button from "@material-ui/core/Button";
-import Dialog from "@material-ui/core/Dialog";
-import DialogActions from "@material-ui/core/DialogActions";
-import DialogContent from "@material-ui/core/DialogContent";
-import DialogTitle from "@material-ui/core/DialogTitle";
 import IconButton from "@material-ui/core/IconButton";
 import SnackbarContent from "@material-ui/core/SnackbarContent";
-import { useTheme } from "@material-ui/core/styles";
 import Tooltip from "@material-ui/core/Tooltip";
-import useMediaQuery from "@material-ui/core/useMediaQuery";
 import SettingsIcon from "@material-ui/icons/Settings";
 import Alert from "@material-ui/lab/Alert";
 import { colors } from "common/colors";
@@ -16,12 +10,12 @@ import { ipcRenderer, shell } from "electron";
 import React from "react";
 import styled from "styled-components";
 
+import { useLoginModal } from "@/lib/hooks/useLoginModal";
 import { useSettingsModal } from "@/lib/hooks/useSettingsModal";
 import { assertPlayKey } from "@/lib/playkey";
 import { useApp } from "@/store/app";
 import { useSettings } from "@/store/settings";
 
-import { LoginForm } from "../LoginForm";
 import { UserMenu } from "./UserMenu";
 
 const handleError = (error: any) => {
@@ -68,11 +62,9 @@ const EnableOnlineSnackBar: React.FC = () => {
 };
 
 export const Header: React.FC = () => {
-  const [loginModalOpen, setLoginModalOpen] = React.useState(false);
+  const openModal = useLoginModal((store) => store.openModal);
   const { open } = useSettingsModal();
   const currentUser = useApp((store) => store.user);
-  const theme = useTheme();
-  const fullScreen = useMediaQuery(theme.breakpoints.down("xs"));
   const meleeIsoPath = useSettings((store) => store.settings.isoPath) || undefined;
   const showSnackbar = useApp((state) => state.showSnackbar);
   const dismissSnackbar = useApp((state) => state.dismissSnackbar);
@@ -108,11 +100,7 @@ export const Header: React.FC = () => {
   return (
     <div>
       <OuterBox display="flex" flexDirection="row" justifyContent="space-between">
-        {currentUser ? (
-          <Button onClick={onPlay}>Play now</Button>
-        ) : (
-          <Button onClick={() => setLoginModalOpen(true)}>Log in</Button>
-        )}
+        {currentUser ? <Button onClick={onPlay}>Play now</Button> : <Button onClick={openModal}>Log in</Button>}
         <Box display="flex" alignItems="center">
           {currentUser && <UserMenu user={currentUser} handleError={handleError}></UserMenu>}
           <Tooltip title="Settings">
@@ -122,17 +110,6 @@ export const Header: React.FC = () => {
           </Tooltip>
         </Box>
       </OuterBox>
-      <Dialog open={loginModalOpen} onClose={() => setLoginModalOpen(false)} fullWidth={true} fullScreen={fullScreen}>
-        <DialogTitle>Login</DialogTitle>
-        <DialogContent>
-          <LoginForm onSuccess={() => setLoginModalOpen(false)} />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setLoginModalOpen(false)} color="primary">
-            Cancel
-          </Button>
-        </DialogActions>
-      </Dialog>
     </div>
   );
 };

--- a/src/renderer/containers/Settings/DolphinSettings.tsx
+++ b/src/renderer/containers/Settings/DolphinSettings.tsx
@@ -1,0 +1,98 @@
+import CircularProgress from "@material-ui/core/CircularProgress";
+import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import CheckCircleIcon from "@material-ui/icons/CheckCircle";
+import ErrorIcon from "@material-ui/icons/Error";
+import { DolphinLaunchType } from "common/dolphin";
+import { ipcRenderer as ipc } from "electron-better-ipc";
+import React from "react";
+
+import { PathInput } from "@/components/PathInput";
+import { useSettings } from "@/store/settings";
+
+import { SettingItem } from "./SettingItem";
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    validation: {
+      display: "flex",
+      alignItems: "center",
+      marginRight: 10,
+    },
+    invalid: {
+      color: theme.palette.error.main,
+    },
+    valid: {
+      color: theme.palette.success.main,
+    },
+    validationText: {
+      marginRight: 5,
+      fontWeight: 500,
+    },
+    title: {
+      textTransform: "capitalize",
+    },
+  }),
+);
+
+export const DolphinSettings: React.FC<{ dolphinType: DolphinLaunchType }> = ({ dolphinType }) => {
+  const dolphinPath = useSettings((state) => state.settings[dolphinType].path);
+  const verifying = useSettings((state) => state.verifyingDolphinPath);
+  const isValidDolphinPath = useSettings((state) => state.validDolphinPath);
+  const verifyAndSetDolphinPath = useSettings((state) => state.verifyAndSetDolphinPath);
+  const setDolphinFolderPath = useSettings((state) => state.setDolphinFolderPath);
+  const classes = useStyles();
+  const onDolphinFolderSelect = React.useCallback(
+    (dolphinPath: string) => {
+      setDolphinFolderPath(dolphinType, dolphinPath);
+      verifyAndSetDolphinPath(dolphinType, dolphinPath);
+    },
+    [setDolphinFolderPath],
+  );
+  const configureDolphin = async () => {
+    console.log("configure dolphin pressesd");
+    await ipc.callMain<string, never>("configureDolphin", dolphinType);
+  };
+  const reinstallDolphin = async () => {
+    console.log("reinstall button clicked");
+    await ipc.callMain<string, never>("reinstallDolphin", dolphinType);
+  };
+  return (
+    <div>
+      <Typography variant="h5" className={classes.title}>
+        {dolphinType} Dolphin Options
+      </Typography>
+      <SettingItem name="Dolphin Directory" description="The path to Dolphin.">
+        <PathInput
+          value={dolphinPath !== null ? dolphinPath : ""}
+          onSelect={onDolphinFolderSelect}
+          placeholder="No folder set"
+          disabled={verifying}
+          options={{ properties: ["openDirectory"] }}
+          endAdornment={
+            <div
+              className={`${classes.validation} ${verifying ? "" : classes[isValidDolphinPath ? "valid" : "invalid"]}`}
+            >
+              <span className={classes.validationText}>
+                {verifying ? "Verifying..." : isValidDolphinPath ? "Valid" : "Invalid"}
+              </span>
+              {verifying ? (
+                <CircularProgress size={25} color="inherit" />
+              ) : isValidDolphinPath ? (
+                <CheckCircleIcon />
+              ) : (
+                <ErrorIcon />
+              )}
+            </div>
+          }
+        />
+      </SettingItem>
+      <SettingItem name="Configure Dolphin" description="Open Dolphin to modify settings.">
+        <button onClick={configureDolphin}>Configure Dolphin</button>
+      </SettingItem>
+      <SettingItem name="Reinstall Dolphin" description="Delete and reinstall dolphin">
+        <button onClick={reinstallDolphin}>Reset Dolphin</button>
+      </SettingItem>
+    </div>
+  );
+};

--- a/src/renderer/containers/Settings/index.tsx
+++ b/src/renderer/containers/Settings/index.tsx
@@ -1,6 +1,7 @@
-import Typography from "@material-ui/core/Typography";
+import { DolphinLaunchType } from "common/dolphin";
 import React from "react";
 
+import { DolphinSettings } from "./DolphinSettings";
 import { MeleeOptions } from "./MeleeOptions";
 import { SettingSection } from "./types";
 
@@ -14,22 +15,14 @@ export const settings: SettingSection[] = [
         component: <MeleeOptions />,
       },
       {
-        name: "Settings Page 2",
-        path: "page-2",
-        component: (
-          <div>
-            <Typography variant="h5">Settings Page 2</Typography>
-          </div>
-        ),
+        name: "Netplay Dolphin Settings",
+        path: "netplay-dolphin-settings",
+        component: <DolphinSettings dolphinType={DolphinLaunchType.NETPLAY} />,
       },
       {
-        name: "Settings Page 3",
-        path: "page-3",
-        component: (
-          <div>
-            <Typography variant="h5">Settings Page 3</Typography>
-          </div>
-        ),
+        name: "Playback Dolphin Settings",
+        path: "playback-dolphin-settings",
+        component: <DolphinSettings dolphinType={DolphinLaunchType.PLAYBACK} />,
       },
     ],
   },

--- a/src/renderer/containers/SpectatePage/index.tsx
+++ b/src/renderer/containers/SpectatePage/index.tsx
@@ -1,9 +1,13 @@
+import CircularProgress from "@material-ui/core/CircularProgress";
 import { BroadcasterItem } from "common/types";
 import { ipcRenderer as ipc } from "electron-better-ipc";
 import React from "react";
 import { useQuery } from "react-query";
 
 import { useApp } from "@/store/app";
+
+const SECOND = 1000;
+const AUTO_REFRESH_INTERVAL = 30 * SECOND;
 
 export const SpectatePage: React.FC = () => {
   const currentUser = useApp((store) => store.user);
@@ -14,28 +18,46 @@ export const SpectatePage: React.FC = () => {
     const authToken = await currentUser.getIdToken();
     return ipc.callMain<string, BroadcasterItem[]>("fetchBroadcastList", authToken);
   });
-  const onClickHandler = () => {
-    broadcastListQuery.refetch();
-  };
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      broadcastListQuery.refetch();
+    }, AUTO_REFRESH_INTERVAL);
+    return () => clearInterval(interval);
+  }, []);
+
   const startWatching = (id: string) => {
     return ipc.callMain<string, never>("watchBroadcast", id);
   };
   const currentBroadcasts = broadcastListQuery.data ?? [];
+
   return (
     <div>
       <h1>Spectate</h1>
       <div>
-        <button onClick={onClickHandler}>refresh broadcast list</button>
-        {broadcastListQuery.isFetching && <div>Refreshing...</div>}
-        {currentBroadcasts.map((data) => {
-          return (
-            <div key={data.id}>
-              <div>{data.broadcaster.name}</div>
-              <div>{data.name}</div>
-              <button onClick={() => startWatching(data.id)}>watch</button>
+        <div style={{ display: "flex" }}>
+          {broadcastListQuery.isFetching && (
+            <div style={{ color: "white", marginRight: 5 }}>
+              <CircularProgress color="inherit" size={20} />
             </div>
-          );
-        })}
+          )}
+          <button onClick={() => broadcastListQuery.refetch()} disabled={broadcastListQuery.isFetching}>
+            refresh
+          </button>
+        </div>
+        {currentBroadcasts.length === 0 ? (
+          <div>No users broadcasting to you.</div>
+        ) : (
+          currentBroadcasts.map((data) => {
+            return (
+              <div key={data.id}>
+                <div>{data.broadcaster.name}</div>
+                <div>{data.name}</div>
+                <button onClick={() => startWatching(data.id)}>watch</button>
+              </div>
+            );
+          })
+        )}
       </div>
     </div>
   );

--- a/src/renderer/containers/SpectatePage/index.tsx
+++ b/src/renderer/containers/SpectatePage/index.tsx
@@ -1,0 +1,42 @@
+import { BroadcasterItem } from "common/types";
+import { ipcRenderer as ipc } from "electron-better-ipc";
+import React from "react";
+import { useQuery } from "react-query";
+
+import { useApp } from "@/store/app";
+
+export const SpectatePage: React.FC = () => {
+  const currentUser = useApp((store) => store.user);
+  const broadcastListQuery = useQuery(["broadcastList", currentUser], async () => {
+    if (!currentUser) {
+      throw new Error("User is not logged in");
+    }
+    const authToken = await currentUser.getIdToken();
+    return ipc.callMain<string, BroadcasterItem[]>("fetchBroadcastList", authToken);
+  });
+  const onClickHandler = () => {
+    broadcastListQuery.refetch();
+  };
+  const startWatching = (id: string) => {
+    return ipc.callMain<string, never>("watchBroadcast", id);
+  };
+  const currentBroadcasts = broadcastListQuery.data ?? [];
+  return (
+    <div>
+      <h1>Spectate</h1>
+      <div>
+        <button onClick={onClickHandler}>refresh broadcast list</button>
+        {broadcastListQuery.isFetching && <div>Refreshing...</div>}
+        {currentBroadcasts.map((data) => {
+          return (
+            <div key={data.id}>
+              <div>{data.broadcaster.name}</div>
+              <div>{data.name}</div>
+              <button onClick={() => startWatching(data.id)}>watch</button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/lib/hooks/useLoginModal.ts
+++ b/src/renderer/lib/hooks/useLoginModal.ts
@@ -1,0 +1,20 @@
+import create from "zustand";
+import { combine } from "zustand/middleware";
+
+export const useLoginModal = create(
+  combine(
+    {
+      open: false,
+    },
+    (set) => ({
+      openModal: () =>
+        set({
+          open: true,
+        }),
+      closeModal: () =>
+        set({
+          open: false,
+        }),
+    }),
+  ),
+);

--- a/src/renderer/views/HomeView.tsx
+++ b/src/renderer/views/HomeView.tsx
@@ -7,6 +7,7 @@ import { Broadcast } from "@/containers/Broadcast";
 import { Header } from "@/containers/Header";
 import { Home } from "@/containers/Home";
 import { ReplayBrowser } from "@/containers/ReplayBrowser";
+import { SpectatePage } from "@/containers/SpectatePage";
 
 const MenuButton = styled.div<{
   selected?: boolean;
@@ -56,7 +57,7 @@ export const HomeView: React.FC = () => {
             <ReplayBrowser />
           </Route>
           <Route path={`${path}/spectate`}>
-            <h1>Spectate</h1>
+            <SpectatePage />
           </Route>
           <Route path={`${path}/broadcast`}>
             <Broadcast />

--- a/src/renderer/views/HomeView.tsx
+++ b/src/renderer/views/HomeView.tsx
@@ -1,4 +1,9 @@
 import Button from "@material-ui/core/ButtonBase";
+import Dialog from "@material-ui/core/Dialog";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import { useTheme } from "@material-ui/core/styles";
+import useMediaQuery from "@material-ui/core/useMediaQuery";
 import React from "react";
 import { Link, Redirect, Route, Switch, useHistory, useRouteMatch } from "react-router-dom";
 import styled from "styled-components";
@@ -6,8 +11,10 @@ import styled from "styled-components";
 import { Broadcast } from "@/containers/Broadcast";
 import { Header } from "@/containers/Header";
 import { Home } from "@/containers/Home";
+import { LoginForm } from "@/containers/LoginForm";
 import { ReplayBrowser } from "@/containers/ReplayBrowser";
 import { SpectatePage } from "@/containers/SpectatePage";
+import { useLoginModal } from "@/lib/hooks/useLoginModal";
 
 const MenuButton = styled.div<{
   selected?: boolean;
@@ -22,6 +29,10 @@ export const HomeView: React.FC = () => {
     return history.location.pathname === `${path}/${name}`;
   };
   const { path } = useRouteMatch();
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down("xs"));
+  const closeModal = useLoginModal((store) => store.closeModal);
+  const loginModalOpen = useLoginModal((store) => store.open);
   return (
     <div
       style={{
@@ -65,6 +76,12 @@ export const HomeView: React.FC = () => {
           <Redirect exact from={path} to={`${path}/home`} />
         </Switch>
       </div>
+      <Dialog open={loginModalOpen} onClose={closeModal} fullWidth={true} fullScreen={fullScreen}>
+        <DialogTitle>Slippi Login</DialogTitle>
+        <DialogContent>
+          <LoginForm onSuccess={closeModal} />
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/src/renderer/views/HomeView.tsx
+++ b/src/renderer/views/HomeView.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import { Link, Redirect, Route, Switch, useHistory, useRouteMatch } from "react-router-dom";
 import styled from "styled-components";
 
+import { PrivateRoute } from "@/components/PrivateRoute";
 import { Broadcast } from "@/containers/Broadcast";
 import { Header } from "@/containers/Header";
 import { Home } from "@/containers/Home";
@@ -67,12 +68,12 @@ export const HomeView: React.FC = () => {
           <Route path={`${path}/replays`}>
             <ReplayBrowser />
           </Route>
-          <Route path={`${path}/spectate`}>
+          <PrivateRoute path={`${path}/spectate`}>
             <SpectatePage />
-          </Route>
-          <Route path={`${path}/broadcast`}>
+          </PrivateRoute>
+          <PrivateRoute path={`${path}/broadcast`}>
             <Broadcast />
-          </Route>
+          </PrivateRoute>
           <Redirect exact from={path} to={`${path}/home`} />
         </Switch>
       </div>

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -53,7 +53,8 @@ export const SettingsView: React.FC = () => {
     return history.location.pathname === `${path}/${name}`;
   };
 
-  const keyDownFunction = (event: any) => {
+  const keyDownFunction = (event: KeyboardEvent) => {
+    // ignore depercation warning, it works everywhere
     if (event.keyCode === 27) {
       close();
     }


### PR DESCRIPTION
This PR adds the following:
* ability to spectate player matches
* protected routes for functions requiring user login
* settings page for configuring Dolphin
* auto-refreshing of players broadcasting (every 30 seconds)

At the moment there is no ability to change the folder where spectate SLP files are stored. That will come later.
