### PR TITLE
chore(deps): replace node-sass with sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "eslint-plugin-strict-booleans": "^1.0.1",
     "husky": "^4.3.0",
-    "node-sass": "^5.0.0",
+    "sass": "^1.34.1",
     "patch-package": "^6.2.2",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.2.1",


### PR DESCRIPTION
Replace the [depreciated](https://www.npmjs.com/package/node-sass)  **node-sass** with the javascript distribution of the official implementation of sass written in dart.